### PR TITLE
feat(admin-shell): brand token system — CSS vars + Tailwind theme

### DIFF
--- a/src/admin/components/ui/BrandTokensShowcase.tsx
+++ b/src/admin/components/ui/BrandTokensShowcase.tsx
@@ -1,0 +1,116 @@
+/**
+ * @description
+ * Visual showcase of every Admin Shell v2 design token. Renders swatches for
+ * brand, surface, text, border, workflow, lock, and language tokens so authors
+ * and developers can verify token values at a glance.
+ *
+ * @notes
+ * - Pure-presentation component. No data fetching, no state.
+ * - Consumed by Storybook in a future issue (`BrandTokensShowcase.stories.tsx`)
+ *   once Storybook is wired into the admin shell. Until then it's renderable
+ *   from any admin route as a smoke screen.
+ * - All colors are read via CSS variables so updating tokens propagates here.
+ */
+
+import * as React from 'react'
+
+type Swatch = {
+  name: string
+  cssVar: string
+  textOn?: 'light' | 'dark'
+}
+
+type Group = {
+  title: string
+  swatches: Swatch[]
+}
+
+const GROUPS: Group[] = [
+  {
+    title: 'Brand',
+    swatches: [
+      { name: 'brand-fras', cssVar: '--brand-fras', textOn: 'dark' },
+      { name: 'brand-fras-tint', cssVar: '--brand-fras-tint', textOn: 'dark' },
+      { name: 'brand-fras-shade', cssVar: '--brand-fras-shade', textOn: 'dark' },
+      { name: 'brand-councils', cssVar: '--brand-councils', textOn: 'dark' },
+      { name: 'brand-councils-tint', cssVar: '--brand-councils-tint', textOn: 'dark' },
+      { name: 'brand-boards', cssVar: '--brand-boards', textOn: 'dark' },
+      { name: 'brand-boards-tint', cssVar: '--brand-boards-tint', textOn: 'dark' },
+      { name: 'brand-neutral', cssVar: '--brand-neutral', textOn: 'light' },
+    ],
+  },
+  {
+    title: 'Workflow states',
+    swatches: [
+      { name: 'workflow-draft', cssVar: '--workflow-draft', textOn: 'dark' },
+      { name: 'workflow-review', cssVar: '--workflow-review', textOn: 'dark' },
+      { name: 'workflow-revision', cssVar: '--workflow-revision', textOn: 'dark' },
+      { name: 'workflow-approved', cssVar: '--workflow-approved', textOn: 'dark' },
+      { name: 'workflow-published', cssVar: '--workflow-published', textOn: 'dark' },
+    ],
+  },
+  {
+    title: 'Lock & language',
+    swatches: [
+      { name: 'lock-locked', cssVar: '--lock-locked', textOn: 'dark' },
+      { name: 'lock-unlocked', cssVar: '--lock-unlocked', textOn: 'dark' },
+      { name: 'lang-missing', cssVar: '--lang-missing', textOn: 'dark' },
+      { name: 'lang-complete', cssVar: '--lang-complete', textOn: 'dark' },
+    ],
+  },
+]
+
+const swatchStyle = (cssVar: string, textOn: 'light' | 'dark' = 'light'): React.CSSProperties => ({
+  backgroundColor: `var(${cssVar})`,
+  color: textOn === 'dark' ? 'var(--text-on-brand)' : 'var(--text-primary)',
+  padding: '12px 14px',
+  borderRadius: '6px',
+  border: '1px solid var(--border-default)',
+  fontSize: '12px',
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px',
+  minHeight: '64px',
+  justifyContent: 'space-between',
+})
+
+export const BrandTokensShowcase: React.FC = () => (
+  <div
+    style={{
+      padding: '24px',
+      backgroundColor: 'var(--surface-page)',
+      color: 'var(--text-primary)',
+      fontFamily: 'system-ui, -apple-system, sans-serif',
+    }}
+  >
+    <h1 style={{ fontSize: '20px', marginBottom: '4px' }}>Admin Shell v2 — Brand Tokens</h1>
+    <p style={{ color: 'var(--text-muted)', fontSize: '14px', marginBottom: '24px' }}>
+      All colors below resolve from CSS variables defined in <code>admin-tailwind.css</code>.
+    </p>
+
+    {GROUPS.map((group) => (
+      <section key={group.title} style={{ marginBottom: '24px' }}>
+        <h2 style={{ fontSize: '14px', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--text-secondary)', marginBottom: '8px' }}>
+          {group.title}
+        </h2>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+            gap: '8px',
+          }}
+        >
+          {group.swatches.map((s) => (
+            <div key={s.cssVar} style={swatchStyle(s.cssVar, s.textOn)}>
+              <strong>{s.name}</strong>
+              <span>{s.cssVar}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+    ))}
+  </div>
+)
+
+export default BrandTokensShowcase

--- a/src/app/(payload)/admin-tailwind.css
+++ b/src/app/(payload)/admin-tailwind.css
@@ -1,0 +1,136 @@
+/**
+ * @description
+ * Brand + semantic design tokens for the custom Admin Shell v2.
+ * Lifts FRAS Canada brand colors into CSS custom properties on :root and
+ * exposes them to Tailwind v4 via the `@theme inline` directive.
+ *
+ * @notes
+ * - All tokens are defined as CSS variables so they can be themed at runtime
+ *   and consumed from JS/TS without re-importing constants.
+ * - Per-board accent colors mirror src/config/brand.ts intent (FRAS purple,
+ *   councils blue, boards red-brown).
+ * - Workflow + lock + language tokens are semantic, not brand — they wrap
+ *   neutral signal colors so the meaning stays portable across themes.
+ * - Source paths register every admin TSX file so the Tailwind JIT picks up
+ *   utility class usage from src/admin/**.
+ */
+
+@import 'tailwindcss';
+
+@source "../../admin/**/*.{ts,tsx}";
+@source "../../app/(payload)/**/*.{ts,tsx}";
+
+/* ── Raw tokens on :root ────────────────────────────────────────────────── */
+:root {
+  /* Brand — board / council accents */
+  --brand-fras: #601F5B;
+  --brand-fras-tint: #8E3387;
+  --brand-fras-shade: #4A1746;
+  --brand-councils: #00438C;
+  --brand-councils-tint: #7986B9;
+  --brand-boards: #983232;
+  --brand-boards-tint: #C98578;
+  --brand-neutral: #A7A9AB;
+
+  /* Surfaces */
+  --surface-page: #FFFFFF;
+  --surface-elevated: #F8F8F8;
+  --surface-sunken: #F0F0F0;
+  --surface-overlay: rgba(0, 0, 0, 0.5);
+
+  /* Text */
+  --text-primary: #1F1F1F;
+  --text-secondary: #525252;
+  --text-muted: #696969;
+  --text-on-brand: #FFFFFF;
+
+  /* Borders */
+  --border-default: #E5E5E5;
+  --border-strong: #C4C4C4;
+  --border-focus: var(--brand-fras);
+
+  /* Semantic — workflow states */
+  --workflow-draft: #696969;
+  --workflow-draft-bg: #F0F0F0;
+  --workflow-review: #B97500;
+  --workflow-review-bg: #FFF4E5;
+  --workflow-revision: #C72C2C;
+  --workflow-revision-bg: #FDECEC;
+  --workflow-approved: #1F7A3F;
+  --workflow-approved-bg: #E8F5EE;
+  --workflow-published: #00438C;
+  --workflow-published-bg: #E5EEF7;
+
+  /* Semantic — lock state */
+  --lock-locked: #B97500;
+  --lock-locked-bg: #FFF4E5;
+  --lock-unlocked: #696969;
+
+  /* Semantic — language warning */
+  --lang-missing: #C72C2C;
+  --lang-missing-bg: #FDECEC;
+  --lang-complete: #1F7A3F;
+  --lang-complete-bg: #E8F5EE;
+
+  /* Focus ring (WCAG 2.2 §2.4.11) */
+  --focus-ring: var(--brand-fras);
+}
+
+/* ── Tailwind theme bridge ──────────────────────────────────────────────── */
+@theme inline {
+  /* Brand */
+  --color-brand-fras: var(--brand-fras);
+  --color-brand-fras-tint: var(--brand-fras-tint);
+  --color-brand-fras-shade: var(--brand-fras-shade);
+  --color-brand-councils: var(--brand-councils);
+  --color-brand-councils-tint: var(--brand-councils-tint);
+  --color-brand-boards: var(--brand-boards);
+  --color-brand-boards-tint: var(--brand-boards-tint);
+  --color-brand-neutral: var(--brand-neutral);
+
+  /* Surfaces */
+  --color-surface-page: var(--surface-page);
+  --color-surface-elevated: var(--surface-elevated);
+  --color-surface-sunken: var(--surface-sunken);
+
+  /* Text */
+  --color-text-primary: var(--text-primary);
+  --color-text-secondary: var(--text-secondary);
+  --color-text-muted: var(--text-muted);
+  --color-text-on-brand: var(--text-on-brand);
+
+  /* Borders */
+  --color-border-default: var(--border-default);
+  --color-border-strong: var(--border-strong);
+  --color-border-focus: var(--border-focus);
+
+  /* Workflow */
+  --color-workflow-draft: var(--workflow-draft);
+  --color-workflow-draft-bg: var(--workflow-draft-bg);
+  --color-workflow-review: var(--workflow-review);
+  --color-workflow-review-bg: var(--workflow-review-bg);
+  --color-workflow-revision: var(--workflow-revision);
+  --color-workflow-revision-bg: var(--workflow-revision-bg);
+  --color-workflow-approved: var(--workflow-approved);
+  --color-workflow-approved-bg: var(--workflow-approved-bg);
+  --color-workflow-published: var(--workflow-published);
+  --color-workflow-published-bg: var(--workflow-published-bg);
+
+  /* Lock */
+  --color-lock-locked: var(--lock-locked);
+  --color-lock-locked-bg: var(--lock-locked-bg);
+  --color-lock-unlocked: var(--lock-unlocked);
+
+  /* Language */
+  --color-lang-missing: var(--lang-missing);
+  --color-lang-missing-bg: var(--lang-missing-bg);
+  --color-lang-complete: var(--lang-complete);
+  --color-lang-complete-bg: var(--lang-complete-bg);
+}
+
+/* ── WCAG 2.2 §2.4.11 focus ring ─────────────────────────────────────────── */
+*:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: 4px;
+}

--- a/src/app/(payload)/layout.tsx
+++ b/src/app/(payload)/layout.tsx
@@ -14,6 +14,7 @@ import config from '@payload-config'
 import { handleServerFunctions, RootLayout } from '@payloadcms/next/layouts'
 import React from 'react'
 
+import './admin-tailwind.css'
 import './custom.scss'
 import { importMap } from './admin/importMap.js'
 


### PR DESCRIPTION
## Summary
- Lifts brand colors into `:root` CSS custom properties at `src/app/(payload)/admin-tailwind.css` and bridges them into Tailwind v4's `@theme inline` block.
- Adds semantic tokens for workflow states (draft, review, revision, approved, published), lock state, language warning/complete, and per-board accents (FRAS purple `#601F5B`, councils blue `#00438C`, boards red-brown `#983232`).
- Establishes `src/admin/**` with a presentational `BrandTokensShowcase` that demos every token visually — ready to wrap as a Storybook story when Storybook is wired into the admin shell in a follow-on issue.

## Acceptance criteria
- [x] CSS variables defined on `:root` for all brand + semantic tokens
- [x] Tailwind `@theme` block consumes the CSS vars
- [x] `grep -r "#601F5B" src/admin/` returns zero hits
- [x] Storybook example demonstrates token usage — delivered as `BrandTokensShowcase.tsx` (Storybook itself isn't installed in `main` yet; component is ready to be wrapped when it lands)
- [x] `tsc --noEmit` clean

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — passes (Next.js 16 / Turbopack)
- [x] `grep -r "#601F5B" src/admin/` — zero hits

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)