### PR TITLE
feat(admin-shell): restructure routes under /admin/* with shell layout

### DIFF
--- a/src/app/(payload)/admin/layout.tsx
+++ b/src/app/(payload)/admin/layout.tsx
@@ -1,0 +1,26 @@
+/**
+ * @description
+ * Layout for `/admin/*` routes. Mounts `<AdminShell>` as the outer chrome.
+ * Custom routes (e.g. `/admin/tree`) render inside the shell. Payload's
+ * existing `[[...segments]]` catch-all still resolves anything else under
+ * `/admin/*` (transitional — Layer 8 retires it).
+ *
+ * @notes
+ * - This layout sits *inside* Payload's `(payload)/layout.tsx → <RootLayout>`,
+ *   so Payload's stock pages (rendered by the catch-all) will visually
+ *   nest within `<AdminShell>`. The doubled chrome is intentional for the
+ *   transitional period and disappears once each surface migrates to a
+ *   native edit view.
+ * - Slot props left empty here are filled by sibling Layer 0 issues
+ *   (#6 left tree, #7 action bar, #8 language switcher, #10 auth bridge).
+ */
+
+import * as React from 'react'
+
+import { AdminShell } from '../../../admin/components/shell/AdminShell'
+
+const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <AdminShell>{children}</AdminShell>
+)
+
+export default Layout

--- a/src/app/(payload)/admin/tree/page.tsx
+++ b/src/app/(payload)/admin/tree/page.tsx
@@ -1,0 +1,24 @@
+/**
+ * @description
+ * `/admin/tree` — first custom route inside the new `<AdminShell>`.
+ * Placeholder workspace until #6 lands the persistent left tree spine.
+ *
+ * @notes
+ * - Rendered inside `<AdminShell>` via `(payload)/admin/layout.tsx`.
+ * - When #6 ships, this route's role shifts to whatever appears in the
+ *   workspace when the user is browsing tree-only context.
+ */
+
+import * as React from 'react'
+
+const Page: React.FC = () => (
+  <div style={{ padding: 24, color: 'var(--text-primary)' }}>
+    <h1 style={{ marginTop: 0, fontSize: 22 }}>Content tree</h1>
+    <p style={{ color: 'var(--text-muted)' }}>
+      This route renders inside <code>{'<AdminShell>'}</code>. The persistent left tree
+      spine and inline tree workspace land in #6.
+    </p>
+  </div>
+)
+
+export default Page


### PR DESCRIPTION
## Summary
- New layout at `src/app/(payload)/admin/layout.tsx` mounts `<AdminShell>`.
- First custom route `/admin/tree` renders inside the shell as a placeholder workspace.
- Payload's `admin/[[...segments]]` catch-all still resolves collection routes — it now renders nested inside AdminShell. The doubled chrome is intentional and retires in Layer 8.

## Acceptance criteria
- [x] New layout at `src/app/(payload)/admin/layout.tsx` mounts `<AdminShell>`
- [x] `/admin/tree` renders inside the shell
- [x] Payload's catch-all still renders for collection routes (transitional)
- [x] `tsc --noEmit` clean

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes — both `/admin/[[...segments]]` and `/admin/tree` register

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)