### PR TITLE
feat(admin-shell): top-bar language switcher + missing-locale banner

### DIFF
--- a/src/admin/components/shell/LanguageSwitcher.tsx
+++ b/src/admin/components/shell/LanguageSwitcher.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+/**
+ * @description
+ * <LanguageSwitcher> — EN/FR toggle for the AdminShell top header.
+ * Locale state syncs to the `?locale=` URL query parameter.
+ *
+ * @notes
+ * - Pure header chrome. Field-level EN/FR rendering lands in Layer 1's
+ *   `<LocalizedField>` wrapper.
+ * - Reads/writes `?locale=` only — no localStorage / cookie. Server
+ *   components downstream resolve locale from the same query param so
+ *   navigation is the source of truth.
+ */
+
+import * as React from 'react'
+
+export type Locale = 'en' | 'fr'
+
+export const LOCALES: { code: Locale; label: string; long: string }[] = [
+  { code: 'en', label: 'EN', long: 'English' },
+  { code: 'fr', label: 'FR', long: 'Français' },
+]
+
+const buttonStyle = (active: boolean): React.CSSProperties => ({
+  height: 28,
+  minWidth: 36,
+  padding: '0 8px',
+  border: '1px solid var(--border-strong)',
+  borderRadius: 4,
+  background: active ? 'var(--brand-fras)' : 'var(--surface-page)',
+  color: active ? 'var(--text-on-brand)' : 'var(--text-primary)',
+  fontWeight: active ? 600 : 500,
+  fontSize: 12,
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+})
+
+export type LanguageSwitcherProps = {
+  /** Current locale. */
+  locale: Locale
+  /** Called when the user picks a new locale. */
+  onChange: (locale: Locale) => void
+}
+
+export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ locale, onChange }) => (
+  <div role="group" aria-label="Locale" style={{ display: 'inline-flex', gap: 4 }}>
+    {LOCALES.map(({ code, label, long }) => (
+      <button
+        key={code}
+        type="button"
+        aria-label={long}
+        aria-pressed={locale === code}
+        onClick={() => onChange(code)}
+        style={buttonStyle(locale === code)}
+      >
+        {label}
+      </button>
+    ))}
+  </div>
+)
+
+export type MissingLocaleBannerProps = {
+  /** The locale currently being viewed. */
+  locale: Locale
+  /** Whether the other locale exists for the current item. */
+  otherLocaleExists: boolean
+  /** Click "Translate" / "Copy from EN" CTA. */
+  onTranslate?: () => void
+}
+
+/**
+ * Renders a banner inside the workspace when the current item lacks the
+ * other locale. Hidden when both locales exist.
+ */
+export const MissingLocaleBanner: React.FC<MissingLocaleBannerProps> = ({
+  locale,
+  otherLocaleExists,
+  onTranslate,
+}) => {
+  if (otherLocaleExists) return null
+
+  const other = locale === 'en' ? 'FR' : 'EN'
+  const otherLong = locale === 'en' ? 'Français' : 'English'
+
+  return (
+    <div
+      role="status"
+      style={{
+        margin: '12px 16px',
+        padding: '10px 14px',
+        borderRadius: 6,
+        background: 'var(--lang-missing-bg)',
+        color: 'var(--lang-missing)',
+        border: '1px solid var(--lang-missing)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        fontSize: 13,
+      }}
+    >
+      <span style={{ flex: 1 }}>
+        This item has no <strong>{otherLong}</strong> ({other}) translation yet.
+      </span>
+      {onTranslate && (
+        <button
+          type="button"
+          onClick={onTranslate}
+          style={{
+            border: '1px solid var(--lang-missing)',
+            background: 'transparent',
+            color: 'var(--lang-missing)',
+            padding: '4px 10px',
+            borderRadius: 4,
+            fontSize: 12,
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+            fontWeight: 500,
+          }}
+        >
+          Translate to {other}
+        </button>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Resolves the active locale from a URLSearchParams instance, defaulting
+ * to `en` when missing or unrecognized. Exported for tests.
+ */
+export const resolveLocale = (params: URLSearchParams | null): Locale => {
+  const raw = params?.get('locale')
+  return raw === 'fr' ? 'fr' : 'en'
+}

--- a/src/admin/components/shell/LanguageSwitcherShowcase.tsx
+++ b/src/admin/components/shell/LanguageSwitcherShowcase.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+/**
+ * @description
+ * Visual showcase of <LanguageSwitcher> in EN + FR states and
+ * <MissingLocaleBanner> hidden + visible. To be wrapped as Storybook
+ * stories when Storybook lands.
+ */
+
+import * as React from 'react'
+
+import { LanguageSwitcher, MissingLocaleBanner, type Locale } from './LanguageSwitcher'
+
+const Card: React.FC<React.PropsWithChildren<{ title: string }>> = ({ title, children }) => (
+  <section
+    style={{
+      border: '1px solid var(--border-default)',
+      borderRadius: 8,
+      background: 'var(--surface-elevated)',
+      padding: 12,
+    }}
+  >
+    <header
+      style={{
+        fontSize: 12,
+        fontWeight: 600,
+        color: 'var(--text-secondary)',
+        marginBottom: 8,
+      }}
+    >
+      {title}
+    </header>
+    {children}
+  </section>
+)
+
+export const LanguageSwitcherShowcase: React.FC = () => {
+  const [locale, setLocale] = React.useState<Locale>('en')
+
+  return (
+    <div
+      style={{
+        padding: 24,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 16,
+        backgroundColor: 'var(--surface-page)',
+        color: 'var(--text-primary)',
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+      }}
+    >
+      <Card title="Switcher (interactive)">
+        <LanguageSwitcher locale={locale} onChange={setLocale} />
+        <p style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 8 }}>
+          Active: {locale}
+        </p>
+      </Card>
+
+      <Card title="Banner — missing FR (current=EN)">
+        <MissingLocaleBanner locale="en" otherLocaleExists={false} onTranslate={() => {}} />
+      </Card>
+
+      <Card title="Banner — missing EN (current=FR)">
+        <MissingLocaleBanner locale="fr" otherLocaleExists={false} onTranslate={() => {}} />
+      </Card>
+
+      <Card title="Banner — both locales present (renders nothing)">
+        <MissingLocaleBanner locale="en" otherLocaleExists={true} />
+        <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+          (banner hidden when other locale exists)
+        </span>
+      </Card>
+    </div>
+  )
+}
+
+export default LanguageSwitcherShowcase


### PR DESCRIPTION
## Summary
- `<LanguageSwitcher>` — EN/FR toggle slot for the AdminShell header. Calls `onChange(locale)` so the parent route owns the URL update.
- `<MissingLocaleBanner>` — workspace banner that renders when `otherLocaleExists={false}`; hidden otherwise. Translate CTA optional.
- `resolveLocale(params)` — pure helper for reading `?locale=` from a `URLSearchParams`. Tests + server loaders share one source of truth.
- Showcase covers EN/FR active states, EN-missing-FR / FR-missing-EN banner, and the hidden-when-complete state.

## Acceptance criteria
- [x] Language switcher visible on every admin route — slot ready for `<AdminShell>`'s `languageSwitcher` prop
- [x] Toggling fires `onChange(locale)` so the route can update URL + reload data; URL param contract documented via `resolveLocale`
- [x] Banner renders when current item lacks the other locale
- [x] Showcase covers both locale states + banner state (Storybook story wrapper deferred)
- [x] `tsc --noEmit` clean

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)