### PR TITLE
feat(admin-shell): auth bridge — server-gate via payload.auth()

### DIFF
--- a/src/admin/components/shell/UserContext.tsx
+++ b/src/admin/components/shell/UserContext.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+/**
+ * @description
+ * React context exposing the authenticated admin user to descendants
+ * of `<AdminShell>`. Populated by the server-side auth gate and
+ * consumed via `useAdminUser()`.
+ *
+ * @notes
+ * - Minimal user shape — id + email + collection slug. Routes that
+ *   need richer profile data should re-query Payload directly via
+ *   TanStack Query rather than threading it through context.
+ */
+
+import * as React from 'react'
+
+export type AdminUser = {
+  id: number | string
+  email: string
+  collection: string
+}
+
+const Context = React.createContext<AdminUser | null>(null)
+
+export const UserProvider: React.FC<React.PropsWithChildren<{ user: AdminUser }>> = ({
+  user,
+  children,
+}) => <Context.Provider value={user}>{children}</Context.Provider>
+
+/**
+ * Returns the current admin user. Throws when called outside of
+ * `<UserProvider>` — that's an authoring bug, not a runtime case.
+ */
+export const useAdminUser = (): AdminUser => {
+  const user = React.useContext(Context)
+  if (!user) {
+    throw new Error('useAdminUser must be called inside <UserProvider>')
+  }
+  return user
+}
+
+/**
+ * Returns the current admin user or null. Use when the calling
+ * component needs to handle a missing provider gracefully (e.g.
+ * during Storybook isolation).
+ */
+export const useAdminUserOrNull = (): AdminUser | null => React.useContext(Context)

--- a/src/admin/lib/auth-gate.ts
+++ b/src/admin/lib/auth-gate.ts
@@ -1,0 +1,35 @@
+/**
+ * @description
+ * Server-only auth bridge for the AdminShell. Reads the current request's
+ * cookies via Next's `headers()` and asks Payload to resolve the user.
+ * Unauthenticated requests redirect to `/admin/login` (Payload's stock
+ * login until Layer 7 ships the branded replacement).
+ *
+ * @notes
+ * - Pure server-side. Do not import from client components.
+ * - Returning the resolved user lets the layout populate `<UserProvider>`
+ *   for client descendants that need user info without a round trip.
+ */
+
+import { redirect } from 'next/navigation'
+import { headers as nextHeaders } from 'next/headers'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+
+import type { AdminUser } from '../components/shell/UserContext'
+
+export const requireAdminUser = async (): Promise<AdminUser> => {
+  const payload = await getPayload({ config })
+  const headers = await nextHeaders()
+  const { user } = await payload.auth({ headers })
+
+  if (!user) {
+    redirect('/admin/login')
+  }
+
+  return {
+    id: user.id,
+    email: user.email ?? '',
+    collection: user.collection,
+  }
+}

--- a/src/app/(payload)/admin/tree/page.tsx
+++ b/src/app/(payload)/admin/tree/page.tsx
@@ -1,24 +1,36 @@
 /**
  * @description
  * `/admin/tree` — first custom route inside the new `<AdminShell>`.
- * Placeholder workspace until #6 lands the persistent left tree spine.
+ * Server-gates via `requireAdminUser()` (see #10) and exposes the
+ * resolved user to client descendants via `<UserProvider>`. Placeholder
+ * workspace until #6 lands the persistent left tree spine.
  *
  * @notes
- * - Rendered inside `<AdminShell>` via `(payload)/admin/layout.tsx`.
- * - When #6 ships, this route's role shifts to whatever appears in the
- *   workspace when the user is browsing tree-only context.
+ * - Auth gate is opt-in per route (not layout-wide) so we don't break
+ *   the unauthenticated entry to Payload's stock `/admin/login` page,
+ *   which still resolves through the catch-all in this transitional
+ *   period.
  */
 
 import * as React from 'react'
 
-const Page: React.FC = () => (
-  <div style={{ padding: 24, color: 'var(--text-primary)' }}>
-    <h1 style={{ marginTop: 0, fontSize: 22 }}>Content tree</h1>
-    <p style={{ color: 'var(--text-muted)' }}>
-      This route renders inside <code>{'<AdminShell>'}</code>. The persistent left tree
-      spine and inline tree workspace land in #6.
-    </p>
-  </div>
-)
+import { UserProvider } from '../../../../admin/components/shell/UserContext'
+import { requireAdminUser } from '../../../../admin/lib/auth-gate'
+
+const Page = async () => {
+  const user = await requireAdminUser()
+
+  return (
+    <UserProvider user={user}>
+      <div style={{ padding: 24, color: 'var(--text-primary)' }}>
+        <h1 style={{ marginTop: 0, fontSize: 22 }}>Content tree</h1>
+        <p style={{ color: 'var(--text-muted)' }}>
+          Signed in as <strong>{user.email}</strong>. The persistent left tree spine and inline
+          tree workspace land in #6.
+        </p>
+      </div>
+    </UserProvider>
+  )
+}
 
 export default Page


### PR DESCRIPTION
## Summary
- New `requireAdminUser()` server-only helper at `src/admin/lib/auth-gate.ts`. Awaits `next/headers`, asks Payload `payload.auth({ headers })`, and either returns `{id, email, collection}` or redirects to `/admin/login`.
- New `<UserProvider>` + `useAdminUser()` / `useAdminUserOrNull()` at `src/admin/components/shell/UserContext.tsx` for client descendants that need user info without a round trip.
- `/admin/tree` updated as the canonical example: page-level gate, then wraps children with `<UserProvider>`.

## Design note: opt-in vs layout-wide
Layout-wide gating (`(payload)/admin/layout.tsx` calling `requireAdminUser()` for every child) would create an infinite redirect loop: visiting `/admin/login` (still served by Payload's catch-all in this transitional layer) would itself trigger the gate, which redirects back to `/admin/login`, etc. Until Layer 7 lands the branded login page outside the gate, custom routes opt in by calling `requireAdminUser()` at the top of their server page component.

## Acceptance criteria
- [x] Unauthenticated request to a gated `/admin/*` route redirects to `/admin/login`
- [x] Authenticated request renders shell with user info available in context
- [x] User context exposed to children via React context (`useAdminUser()`)
- [x] `tsc --noEmit` clean (`npm run build` passes)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)