### PR TITLE
feat(admin-shell): persistent left tree spine

### DIFF
--- a/src/admin/components/tree/GutterIcons.tsx
+++ b/src/admin/components/tree/GutterIcons.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+/**
+ * @description
+ * Tiny inline glyphs for the tree row gutter — workflow state, lock,
+ * and FR-missing. Pure SVG so they inherit color from CSS variables
+ * without sprite assets.
+ */
+
+import * as React from 'react'
+
+import type { WorkflowState } from './types'
+
+const SIZE = 12
+
+const Dot: React.FC<{ color: string; title: string }> = ({ color, title }) => (
+  <svg
+    width={SIZE}
+    height={SIZE}
+    viewBox="0 0 12 12"
+    aria-label={title}
+    role="img"
+    style={{ flexShrink: 0 }}
+  >
+    <title>{title}</title>
+    <circle cx="6" cy="6" r="4" fill={color} />
+  </svg>
+)
+
+const stateColor: Record<WorkflowState, string> = {
+  draft: 'var(--workflow-draft)',
+  'in-review': 'var(--workflow-review)',
+  'needs-revision': 'var(--workflow-revision)',
+  approved: 'var(--workflow-approved)',
+  published: 'var(--workflow-published)',
+}
+
+const stateLabel: Record<WorkflowState, string> = {
+  draft: 'Draft',
+  'in-review': 'In review',
+  'needs-revision': 'Needs revision',
+  approved: 'Approved',
+  published: 'Published',
+}
+
+export const WorkflowGutterIcon: React.FC<{ state: WorkflowState }> = ({ state }) => (
+  <Dot color={stateColor[state]} title={stateLabel[state]} />
+)
+
+export const LockGutterIcon: React.FC = () => (
+  <svg
+    width={SIZE}
+    height={SIZE}
+    viewBox="0 0 12 12"
+    aria-label="Locked"
+    role="img"
+    style={{ flexShrink: 0, color: 'var(--lock-locked)' }}
+  >
+    <title>Locked</title>
+    <path
+      d="M3.5 5V3.5a2.5 2.5 0 0 1 5 0V5h.5a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h.5Zm1 0h3V3.5a1.5 1.5 0 1 0-3 0V5Z"
+      fill="currentColor"
+    />
+  </svg>
+)
+
+export const FrMissingGutterIcon: React.FC = () => (
+  <span
+    aria-label="French translation missing"
+    role="img"
+    title="French translation missing"
+    style={{
+      display: 'inline-block',
+      fontSize: 9,
+      fontWeight: 700,
+      lineHeight: '12px',
+      width: SIZE,
+      height: SIZE,
+      textAlign: 'center',
+      color: 'var(--lang-missing)',
+      border: '1px solid var(--lang-missing)',
+      borderRadius: 2,
+      flexShrink: 0,
+    }}
+  >
+    FR
+  </span>
+)
+
+export const Gutter: React.FC<{
+  workflow?: WorkflowState
+  locked?: boolean
+  hasFr?: boolean
+}> = ({ workflow, locked, hasFr }) => (
+  <span style={{ display: 'inline-flex', gap: 3, alignItems: 'center', flexShrink: 0 }}>
+    {workflow ? <WorkflowGutterIcon state={workflow} /> : null}
+    {locked ? <LockGutterIcon /> : null}
+    {hasFr === false ? <FrMissingGutterIcon /> : null}
+  </span>
+)

--- a/src/admin/components/tree/TreeContextMenu.tsx
+++ b/src/admin/components/tree/TreeContextMenu.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+/**
+ * @description
+ * Right-click context menu for tree rows. The "Insert" submenu is
+ * filtered to valid child collection types per `validChildren` so authors
+ * cannot create an invalid hierarchy.
+ *
+ * @notes
+ * - Anchored to a screen position; the parent owns visibility state.
+ * - Closes on outside click + Escape. Clicking a menu item invokes the
+ *   handler then closes.
+ */
+
+import * as React from 'react'
+
+import type { TreeNode, ValidChildMap } from './types'
+
+export type TreeContextAction =
+  | { kind: 'insert'; childCollection: string }
+  | { kind: 'rename' }
+  | { kind: 'delete' }
+  | { kind: 'duplicate' }
+
+export type TreeContextMenuProps = {
+  node: TreeNode
+  validChildren: ValidChildMap
+  position: { x: number; y: number }
+  onAction: (action: TreeContextAction) => void
+  onClose: () => void
+}
+
+/**
+ * Returns the list of collection slugs allowed as children of this node.
+ * Exported for tests so the filter logic stays unit-checkable in isolation.
+ */
+export const getValidChildren = (node: TreeNode, map: ValidChildMap): readonly string[] =>
+  map[node.collection] ?? []
+
+const itemStyle: React.CSSProperties = {
+  padding: '6px 12px',
+  fontSize: 12,
+  cursor: 'pointer',
+  whiteSpace: 'nowrap',
+  background: 'transparent',
+  border: 'none',
+  textAlign: 'left',
+  color: 'var(--text-primary)',
+  fontFamily: 'inherit',
+  width: '100%',
+}
+
+const sectionStyle: React.CSSProperties = {
+  padding: '4px 12px',
+  fontSize: 10,
+  textTransform: 'uppercase',
+  letterSpacing: '0.04em',
+  color: 'var(--text-muted)',
+}
+
+export const TreeContextMenu: React.FC<TreeContextMenuProps> = ({
+  node,
+  validChildren,
+  position,
+  onAction,
+  onClose,
+}) => {
+  const children = getValidChildren(node, validChildren)
+  const ref = React.useRef<HTMLDivElement>(null)
+
+  React.useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) onClose()
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('mousedown', onDoc)
+    window.addEventListener('keydown', onKey)
+    return () => {
+      window.removeEventListener('mousedown', onDoc)
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [onClose])
+
+  const fire = (action: TreeContextAction) => {
+    onAction(action)
+    onClose()
+  }
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      aria-label={`Actions for ${node.label}`}
+      style={{
+        position: 'fixed',
+        top: position.y,
+        left: position.x,
+        zIndex: 50,
+        minWidth: 200,
+        padding: '4px 0',
+        background: 'var(--surface-page)',
+        border: '1px solid var(--border-default)',
+        borderRadius: 6,
+        boxShadow: '0 6px 20px rgba(0, 0, 0, 0.12)',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      {children.length > 0 && (
+        <>
+          <div style={sectionStyle}>Insert</div>
+          {children.map((c) => (
+            <button
+              key={`insert-${c}`}
+              type="button"
+              role="menuitem"
+              style={itemStyle}
+              onClick={() => fire({ kind: 'insert', childCollection: c })}
+            >
+              New <strong>{c}</strong>
+            </button>
+          ))}
+          <div style={{ height: 1, background: 'var(--border-default)', margin: '4px 0' }} />
+        </>
+      )}
+
+      <button type="button" role="menuitem" style={itemStyle} onClick={() => fire({ kind: 'rename' })}>
+        Rename
+      </button>
+      <button type="button" role="menuitem" style={itemStyle} onClick={() => fire({ kind: 'duplicate' })}>
+        Duplicate
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        style={{ ...itemStyle, color: 'var(--workflow-revision)' }}
+        onClick={() => fire({ kind: 'delete' })}
+      >
+        Delete
+      </button>
+    </div>
+  )
+}

--- a/src/admin/components/tree/TreeSpine.tsx
+++ b/src/admin/components/tree/TreeSpine.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+/**
+ * @description
+ * Persistent left tree spine for `<AdminShell>`. Mounted in the layout
+ * so its DOM survives navigation between any `/admin/*` route. Exposes
+ * search, expansion, selection, gutter icons, and a right-click context
+ * menu with valid-child-type filtering.
+ *
+ * @notes
+ * - State persists in module-scope + sessionStorage via `tree-store`.
+ * - Virtualization is intentionally not added at this scaffolding step.
+ *   Real tree data lands later — at that point swap the inner `<ul>` for
+ *   a virtualized list (react-window / @tanstack/react-virtual).
+ */
+
+import * as React from 'react'
+import { useRouter } from 'next/navigation'
+
+import { Gutter } from './GutterIcons'
+import { TreeContextMenu, type TreeContextAction } from './TreeContextMenu'
+import { treeActions, useTreeState } from './tree-store'
+import type { TreeNode, ValidChildMap } from './types'
+
+export type TreeSpineProps = {
+  /** Tree data — typically resolved server-side and passed in. */
+  nodes: TreeNode[]
+  /** Map of parent collection → valid child collections. */
+  validChildren: ValidChildMap
+  /** Optional callback for context menu actions. */
+  onAction?: (node: TreeNode, action: TreeContextAction) => void
+}
+
+type FlatRow = { node: TreeNode; depth: number }
+
+/**
+ * Flattens the tree, respecting the expanded set, and applies the search
+ * query. When a query is active any branch containing a match expands
+ * automatically. Exported for unit tests.
+ */
+export const flattenTree = (
+  nodes: TreeNode[],
+  expanded: ReadonlySet<string>,
+  query: string,
+): FlatRow[] => {
+  const q = query.trim().toLowerCase()
+  const matches = (n: TreeNode): boolean => n.label.toLowerCase().includes(q)
+  const subtreeHasMatch = (n: TreeNode): boolean =>
+    matches(n) || (n.children?.some(subtreeHasMatch) ?? false)
+
+  const out: FlatRow[] = []
+  const walk = (list: TreeNode[], depth: number) => {
+    for (const node of list) {
+      if (q && !subtreeHasMatch(node)) continue
+      out.push({ node, depth })
+      const open = expanded.has(node.id) || (q.length > 0 && (node.children?.some(subtreeHasMatch) ?? false))
+      if (open && node.children) {
+        walk(node.children, depth + 1)
+      }
+    }
+  }
+  walk(nodes, 0)
+  return out
+}
+
+const ROW_HEIGHT = 30
+
+export const TreeSpine: React.FC<TreeSpineProps> = ({ nodes, validChildren, onAction }) => {
+  const router = useRouter()
+  const { selectedId, expanded, query, scrollTop } = useTreeState()
+  const scrollRef = React.useRef<HTMLDivElement>(null)
+  const [menu, setMenu] = React.useState<{ node: TreeNode; x: number; y: number } | null>(null)
+
+  React.useEffect(() => {
+    if (scrollRef.current && scrollRef.current.scrollTop !== scrollTop) {
+      scrollRef.current.scrollTop = scrollTop
+    }
+    // Only restore once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const rows = React.useMemo(() => flattenTree(nodes, expanded, query), [nodes, expanded, query])
+
+  const navigateToNode = (node: TreeNode) => {
+    treeActions.select(node.id)
+    router.push(`/admin/edit/${node.collection}/${node.id}`)
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <div style={{ padding: 8, borderBottom: '1px solid var(--border-default)' }}>
+        <input
+          type="search"
+          placeholder="Filter…"
+          value={query}
+          onChange={(e) => treeActions.setQuery(e.target.value)}
+          aria-label="Filter tree"
+          style={{
+            width: '100%',
+            height: 28,
+            padding: '0 8px',
+            border: '1px solid var(--border-default)',
+            borderRadius: 4,
+            background: 'var(--surface-page)',
+            color: 'var(--text-primary)',
+            fontSize: 12,
+            fontFamily: 'inherit',
+          }}
+        />
+      </div>
+
+      <div
+        ref={scrollRef}
+        onScroll={(e) => treeActions.setScrollTop((e.target as HTMLDivElement).scrollTop)}
+        style={{ flex: 1, overflow: 'auto', padding: '4px 0' }}
+      >
+        {rows.length === 0 ? (
+          <div style={{ padding: 16, color: 'var(--text-muted)', fontSize: 12 }}>
+            No matches.
+          </div>
+        ) : (
+          <ul
+            role="tree"
+            aria-label="Content tree"
+            style={{ listStyle: 'none', margin: 0, padding: 0 }}
+          >
+            {rows.map(({ node, depth }) => {
+              const hasChildren = (node.children?.length ?? 0) > 0
+              const isOpen = expanded.has(node.id)
+              const isSelected = selectedId === node.id
+
+              return (
+                <li
+                  key={node.id}
+                  role="treeitem"
+                  aria-expanded={hasChildren ? isOpen : undefined}
+                  aria-selected={isSelected}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    height: ROW_HEIGHT,
+                    paddingLeft: 8 + depth * 14,
+                    paddingRight: 8,
+                    background: isSelected ? 'var(--surface-sunken)' : 'transparent',
+                    cursor: 'pointer',
+                    fontSize: 13,
+                  }}
+                  onClick={() => {
+                    if (hasChildren) treeActions.toggleExpanded(node.id)
+                    treeActions.select(node.id)
+                  }}
+                  onDoubleClick={() => navigateToNode(node)}
+                  onContextMenu={(e) => {
+                    e.preventDefault()
+                    treeActions.select(node.id)
+                    setMenu({ node, x: e.clientX, y: e.clientY })
+                  }}
+                >
+                  <span
+                    aria-hidden
+                    style={{
+                      width: 12,
+                      color: 'var(--text-muted)',
+                      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                      fontSize: 10,
+                      textAlign: 'center',
+                    }}
+                  >
+                    {hasChildren ? (isOpen ? '▾' : '▸') : ''}
+                  </span>
+                  <Gutter
+                    workflow={node.workflow}
+                    locked={node.locked}
+                    hasFr={node.hasFr}
+                  />
+                  <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                    {node.label}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+
+      {menu && (
+        <TreeContextMenu
+          node={menu.node}
+          validChildren={validChildren}
+          position={{ x: menu.x, y: menu.y }}
+          onAction={(action) => onAction?.(menu.node, action)}
+          onClose={() => setMenu(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+export default TreeSpine

--- a/src/admin/components/tree/TreeSpineDefault.tsx
+++ b/src/admin/components/tree/TreeSpineDefault.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+/**
+ * @description
+ * Wrapper that mounts `<TreeSpine>` with the sample dataset. Used as
+ * the `leftRail` slot in `<AdminShell>` until a live tree loader ships.
+ */
+
+import * as React from 'react'
+
+import { SAMPLE_TREE, SAMPLE_VALID_CHILDREN } from './sample-data'
+import { TreeSpine } from './TreeSpine'
+
+export const TreeSpineDefault: React.FC = () => (
+  <TreeSpine nodes={SAMPLE_TREE} validChildren={SAMPLE_VALID_CHILDREN} />
+)
+
+export default TreeSpineDefault

--- a/src/admin/components/tree/sample-data.ts
+++ b/src/admin/components/tree/sample-data.ts
@@ -1,0 +1,106 @@
+/**
+ * @description
+ * Sample tree data + valid-child map for the AdminShell tree spine.
+ * Covers the typical FRAS Canada hierarchy (boards, news, projects, etc.)
+ * so the tree renders meaningful content during scaffolding before real
+ * Payload-backed data lands.
+ *
+ * @notes
+ * - Replace this with a real loader once `/api/tree` returns live data.
+ * - Collection slugs match canonical names from CLAUDE.md "Canonical
+ *   Collection Names" table.
+ */
+
+import type { TreeNode, ValidChildMap } from './types'
+
+export const SAMPLE_TREE: TreeNode[] = [
+  {
+    id: 'home',
+    slug: '',
+    label: 'Home',
+    collection: 'pages',
+    workflow: 'published',
+    hasFr: true,
+    children: [
+      {
+        id: 'boards',
+        slug: 'boards',
+        label: 'Boards & Councils',
+        collection: 'boards',
+        workflow: 'published',
+        hasFr: true,
+        children: [
+          {
+            id: 'acsb',
+            slug: 'acsb',
+            label: 'AcSB',
+            collection: 'board-detail',
+            workflow: 'published',
+            hasFr: true,
+          },
+          {
+            id: 'aasb',
+            slug: 'aasb',
+            label: 'AASB',
+            collection: 'board-detail',
+            workflow: 'published',
+            hasFr: false,
+          },
+          {
+            id: 'psab',
+            slug: 'psab',
+            label: 'PSAB',
+            collection: 'board-detail',
+            workflow: 'in-review',
+            hasFr: true,
+          },
+        ],
+      },
+      {
+        id: 'news',
+        slug: 'news',
+        label: 'News',
+        collection: 'news',
+        workflow: 'published',
+        hasFr: true,
+        children: [
+          {
+            id: 'news-2026-q1',
+            slug: 'q1-update',
+            label: '2026 Q1 update',
+            collection: 'news',
+            workflow: 'draft',
+            hasFr: false,
+            locked: true,
+          },
+        ],
+      },
+      {
+        id: 'projects',
+        slug: 'active-projects',
+        label: 'Active projects',
+        collection: 'projects',
+        workflow: 'published',
+        hasFr: true,
+        children: [
+          {
+            id: 'sustainability-2026',
+            slug: 'sustainability-2026',
+            label: 'Sustainability standards 2026',
+            collection: 'projects',
+            workflow: 'needs-revision',
+            hasFr: true,
+          },
+        ],
+      },
+    ],
+  },
+]
+
+export const SAMPLE_VALID_CHILDREN: ValidChildMap = {
+  pages: ['pages', 'news', 'projects', 'boards'],
+  boards: ['board-detail'],
+  'board-detail': ['committees', 'board-members'],
+  news: ['news'],
+  projects: ['projects'],
+}

--- a/src/admin/components/tree/tree-store.ts
+++ b/src/admin/components/tree/tree-store.ts
@@ -1,0 +1,120 @@
+'use client'
+
+/**
+ * @description
+ * Persistent tree state store. Selection, expanded set, search query, and
+ * scroll position survive navigation between any `/admin/*` route because
+ * the store is module-scoped — its lifetime is the tab session, not any
+ * single route.
+ *
+ * Implemented with a hand-rolled external store + `useSyncExternalStore`
+ * to avoid pulling in zustand at this scaffolding stage. The shape is
+ * intentionally close to zustand's so swapping is mechanical when the
+ * dep lands.
+ *
+ * @notes
+ * - Pure client module. The tree spine renders inside a 'use client' tree.
+ * - Persisted to `sessionStorage` under one key so a hard reload restores
+ *   selection + expansion. SSR-safe — guarded by `typeof window`.
+ */
+
+import * as React from 'react'
+
+const STORAGE_KEY = 'fras.admin.tree.v1'
+
+export type TreeState = {
+  selectedId: string | null
+  expanded: ReadonlySet<string>
+  query: string
+  scrollTop: number
+}
+
+const initialState: TreeState = {
+  selectedId: null,
+  expanded: new Set<string>(),
+  query: '',
+  scrollTop: 0,
+}
+
+const readPersisted = (): TreeState => {
+  if (typeof window === 'undefined') return initialState
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY)
+    if (!raw) return initialState
+    const parsed = JSON.parse(raw) as {
+      selectedId: string | null
+      expanded: string[]
+      query: string
+      scrollTop: number
+    }
+    return {
+      selectedId: parsed.selectedId ?? null,
+      expanded: new Set(parsed.expanded ?? []),
+      query: parsed.query ?? '',
+      scrollTop: parsed.scrollTop ?? 0,
+    }
+  } catch {
+    return initialState
+  }
+}
+
+const writePersisted = (state: TreeState) => {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        selectedId: state.selectedId,
+        expanded: Array.from(state.expanded),
+        query: state.query,
+        scrollTop: state.scrollTop,
+      }),
+    )
+  } catch {
+    /* swallow quota errors — losing tree state is recoverable */
+  }
+}
+
+let state: TreeState = readPersisted()
+const listeners = new Set<() => void>()
+
+const setState = (next: Partial<TreeState>) => {
+  state = { ...state, ...next }
+  writePersisted(state)
+  listeners.forEach((l) => l())
+}
+
+const subscribe = (l: () => void) => {
+  listeners.add(l)
+  return () => {
+    listeners.delete(l)
+  }
+}
+
+const getSnapshot = () => state
+const getServerSnapshot = () => initialState
+
+/**
+ * Hook reading the full tree state. Components that only need a slice
+ * should read from this and select with their own memo / equality check.
+ */
+export const useTreeState = (): TreeState =>
+  React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+
+export const treeActions = {
+  select: (id: string | null) => setState({ selectedId: id }),
+  toggleExpanded: (id: string) => {
+    const next = new Set(state.expanded)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    setState({ expanded: next })
+  },
+  expand: (ids: string[]) => {
+    const next = new Set(state.expanded)
+    ids.forEach((id) => next.add(id))
+    setState({ expanded: next })
+  },
+  setQuery: (query: string) => setState({ query }),
+  setScrollTop: (scrollTop: number) => setState({ scrollTop }),
+  reset: () => setState({ ...initialState, expanded: new Set() }),
+}

--- a/src/admin/components/tree/types.ts
+++ b/src/admin/components/tree/types.ts
@@ -1,0 +1,38 @@
+/**
+ * @description
+ * Type definitions for the persistent left tree spine. Kept dependency-free
+ * so server components, the state store, the tree view, and the context
+ * menu all share the same vocabulary without circular imports.
+ */
+
+export type WorkflowState =
+  | 'draft'
+  | 'in-review'
+  | 'needs-revision'
+  | 'approved'
+  | 'published'
+
+export type TreeNode = {
+  id: string
+  /** Slug used for the URL (e.g. `acsb`, `news`, `events`). */
+  slug: string
+  /** Display label. */
+  label: string
+  /** Collection slug — used by valid-child-type filtering. */
+  collection: string
+  /** Optional children. Absence indicates a leaf. */
+  children?: TreeNode[]
+  /** Workflow state for the gutter icon. */
+  workflow?: WorkflowState
+  /** Whether the item is locked by another user. */
+  locked?: boolean
+  /** Whether the FR locale exists for this item. */
+  hasFr?: boolean
+}
+
+/**
+ * Map of `parent collection` → set of valid `child collection` slugs.
+ * Used by the right-click menu to filter the "Insert" submenu so authors
+ * can only create children of permissible types.
+ */
+export type ValidChildMap = Record<string, readonly string[]>

--- a/src/app/(payload)/admin/layout.tsx
+++ b/src/app/(payload)/admin/layout.tsx
@@ -18,9 +18,10 @@
 import * as React from 'react'
 
 import { AdminShell } from '../../../admin/components/shell/AdminShell'
+import { TreeSpineDefault } from '../../../admin/components/tree/TreeSpineDefault'
 
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <AdminShell>{children}</AdminShell>
+  <AdminShell leftRail={<TreeSpineDefault />}>{children}</AdminShell>
 )
 
 export default Layout


### PR DESCRIPTION
## Summary
- Mounts `<TreeSpine>` in the AdminShell layout's `leftRail` slot — its DOM survives navigation between any `/admin/*` route.
- Module-scoped state store (`tree-store.ts`) backed by `useSyncExternalStore` + sessionStorage. Selection, expansion, search query, and scroll position persist across nav and survive hard reload.
- Search/filter, expand/collapse, single-click select, double-click navigate, right-click context menu.
- Gutter icons render workflow state, lock, and FR-missing — all using semantic tokens.
- Right-click context menu filters the "Insert" submenu by `validChildren` so authors cannot create an invalid hierarchy.
- Sample dataset wired in until `/api/tree` lives.

## Acceptance criteria
- [x] Tree visible on every `/admin/*` route (mounted in the AdminShell layout)
- [x] Selection / expansion / search persist across navigation
- [x] Clicking a node navigates without remounting tree (component lives in the layout)
- [x] Gutter icons render (workflow state, lock, FR-missing)
- [x] Right-click context menu functional with valid-child-type filter
- [x] `tsc --noEmit` clean (`npm run build` passes)

## Notes
- `flattenTree()` and `getValidChildren()` are exported as pure helpers ready for Vitest unit tests when Vitest is wired up.
- Virtualization is intentionally deferred — the sample tree has ~10 nodes. Once the real loader ships, swap the inner `<ul>` for `react-window` / `@tanstack/react-virtual`.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)