### PR TITLE
feat(admin-shell): <EditFormProvider> — form context

### DIFF
--- a/src/admin/components/forms/EditFormProvider.test.tsx
+++ b/src/admin/components/forms/EditFormProvider.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * @description
+ * Vitest coverage for <EditFormProvider> — the largest testable surface
+ * in the v2 admin shell per the PRD. Each test asserts external
+ * behavior (rendered output / observable callback effects) rather than
+ * implementation internals.
+ */
+
+import * as React from 'react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  EditFormProvider,
+  useEditForm,
+  useEditFormField,
+  type FieldValidator,
+} from './EditFormProvider'
+
+afterEach(() => {
+  // Defensive: any test using fake timers should restore real ones,
+  // but fake timers leaking into the next test breaks waitFor.
+  vi.useRealTimers()
+})
+
+const FieldHarness: React.FC<{ name: string; validator?: FieldValidator }> = ({
+  name,
+  validator,
+}) => {
+  const { value, error, dirty, setValue } = useEditFormField(name, validator)
+  return (
+    <div>
+      <input
+        data-testid={`field-${name}`}
+        value={String(value ?? '')}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <span data-testid={`error-${name}`}>{error ?? ''}</span>
+      <span data-testid={`dirty-${name}`}>{dirty ? 'dirty' : 'clean'}</span>
+    </div>
+  )
+}
+
+const FormStateProbe: React.FC = () => {
+  const { isDirty, isValid, submitStatus, canUndo, canRedo } = useEditForm()
+  return (
+    <div>
+      <span data-testid="probe-dirty">{isDirty ? 'dirty' : 'clean'}</span>
+      <span data-testid="probe-valid">{isValid ? 'valid' : 'invalid'}</span>
+      <span data-testid="probe-status">{submitStatus}</span>
+      <span data-testid="probe-undo">{canUndo ? 'can-undo' : 'no-undo'}</span>
+      <span data-testid="probe-redo">{canRedo ? 'can-redo' : 'no-redo'}</span>
+    </div>
+  )
+}
+
+describe('<EditFormProvider> dirty tracking', () => {
+  it('starts clean', () => {
+    render(
+      <EditFormProvider initialValues={{ title: '' }} onSubmit={async () => {}}>
+        <FieldHarness name="title" />
+        <FormStateProbe />
+      </EditFormProvider>,
+    )
+    expect(screen.getByTestId('probe-dirty').textContent).toBe('clean')
+    expect(screen.getByTestId('dirty-title').textContent).toBe('clean')
+  })
+
+  it('flips to dirty when a field changes', () => {
+    render(
+      <EditFormProvider initialValues={{ title: '' }} onSubmit={async () => {}}>
+        <FieldHarness name="title" />
+        <FormStateProbe />
+      </EditFormProvider>,
+    )
+    fireEvent.change(screen.getByTestId('field-title'), { target: { value: 'hi' } })
+    expect(screen.getByTestId('probe-dirty').textContent).toBe('dirty')
+    expect(screen.getByTestId('dirty-title').textContent).toBe('dirty')
+  })
+
+  it('returns to clean when reverted to initial', () => {
+    render(
+      <EditFormProvider initialValues={{ title: 'a' }} onSubmit={async () => {}}>
+        <FieldHarness name="title" />
+        <FormStateProbe />
+      </EditFormProvider>,
+    )
+    fireEvent.change(screen.getByTestId('field-title'), { target: { value: 'b' } })
+    expect(screen.getByTestId('probe-dirty').textContent).toBe('dirty')
+    fireEvent.change(screen.getByTestId('field-title'), { target: { value: 'a' } })
+    expect(screen.getByTestId('probe-dirty').textContent).toBe('clean')
+  })
+})
+
+describe('<EditFormProvider> validation aggregation', () => {
+  it('invalid when any field has an error', () => {
+    const required: FieldValidator = (v) => (v ? null : 'required')
+    render(
+      <EditFormProvider initialValues={{ a: '', b: 'ok' }} onSubmit={async () => {}}>
+        <FieldHarness name="a" validator={required} />
+        <FieldHarness name="b" validator={required} />
+        <FormStateProbe />
+      </EditFormProvider>,
+    )
+    expect(screen.getByTestId('probe-valid').textContent).toBe('invalid')
+    expect(screen.getByTestId('error-a').textContent).toBe('required')
+    fireEvent.change(screen.getByTestId('field-a'), { target: { value: 'now-set' } })
+    expect(screen.getByTestId('probe-valid').textContent).toBe('valid')
+  })
+})
+
+describe('<EditFormProvider> autosave debouncing', () => {
+  it('debounces submit until quiet period elapses', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false })
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <EditFormProvider
+        initialValues={{ title: '' }}
+        onSubmit={onSubmit}
+        autosave
+        autosaveDebounceMs={500}
+      >
+        <FieldHarness name="title" />
+      </EditFormProvider>,
+    )
+
+    fireEvent.change(screen.getByTestId('field-title'), { target: { value: 'a' } })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+    fireEvent.change(screen.getByTestId('field-title'), { target: { value: 'ab' } })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith({ title: 'ab' })
+  })
+})
+
+describe('<EditFormProvider> undo / redo', () => {
+  const Controls: React.FC = () => {
+    const { undo, redo } = useEditForm()
+    return (
+      <div>
+        <button data-testid="btn-undo" onClick={undo} type="button">
+          undo
+        </button>
+        <button data-testid="btn-redo" onClick={redo} type="button">
+          redo
+        </button>
+      </div>
+    )
+  }
+
+  it('undoes the last value change and exposes redo', () => {
+    render(
+      <EditFormProvider initialValues={{ title: '' }} onSubmit={async () => {}}>
+        <FieldHarness name="title" />
+        <FormStateProbe />
+        <Controls />
+      </EditFormProvider>,
+    )
+    fireEvent.change(screen.getByTestId('field-title'), { target: { value: 'one' } })
+    fireEvent.change(screen.getByTestId('field-title'), { target: { value: 'two' } })
+    expect(screen.getByTestId('field-title').getAttribute('value')).toBe('two')
+
+    fireEvent.click(screen.getByTestId('btn-undo'))
+    expect(screen.getByTestId('field-title').getAttribute('value')).toBe('one')
+    expect(screen.getByTestId('probe-redo').textContent).toBe('can-redo')
+
+    fireEvent.click(screen.getByTestId('btn-redo'))
+    expect(screen.getByTestId('field-title').getAttribute('value')).toBe('two')
+  })
+
+  it('clears the redo stack when a new change happens after undo', () => {
+    render(
+      <EditFormProvider initialValues={{ title: '' }} onSubmit={async () => {}}>
+        <FieldHarness name="title" />
+        <FormStateProbe />
+        <Controls />
+      </EditFormProvider>,
+    )
+    fireEvent.change(screen.getByTestId('field-title'), { target: { value: 'a' } })
+    fireEvent.click(screen.getByTestId('btn-undo'))
+    expect(screen.getByTestId('probe-redo').textContent).toBe('can-redo')
+    fireEvent.change(screen.getByTestId('field-title'), { target: { value: 'b' } })
+    expect(screen.getByTestId('probe-redo').textContent).toBe('no-redo')
+  })
+})
+
+describe('<EditFormProvider> submit lifecycle', () => {
+  const SubmitButton: React.FC = () => {
+    const { submit } = useEditForm()
+    return (
+      <button type="button" data-testid="btn-submit" onClick={() => void submit()}>
+        submit
+      </button>
+    )
+  }
+
+  it('flips through idle → submitting → success', async () => {
+    let resolve: (() => void) | null = null
+    const onSubmit = vi.fn(
+      () => new Promise<void>((r) => (resolve = r)),
+    )
+    render(
+      <EditFormProvider initialValues={{ title: 'a' }} onSubmit={onSubmit}>
+        <FieldHarness name="title" />
+        <FormStateProbe />
+        <SubmitButton />
+      </EditFormProvider>,
+    )
+
+    expect(screen.getByTestId('probe-status').textContent).toBe('idle')
+    fireEvent.click(screen.getByTestId('btn-submit'))
+    await waitFor(() =>
+      expect(screen.getByTestId('probe-status').textContent).toBe('submitting'),
+    )
+    act(() => resolve?.())
+    await waitFor(() => expect(screen.getByTestId('probe-status').textContent).toBe('success'))
+  })
+
+  it('rolls back to error on rejection and preserves field values', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('boom'))
+    render(
+      <EditFormProvider initialValues={{ title: 'a' }} onSubmit={onSubmit}>
+        <FieldHarness name="title" />
+        <FormStateProbe />
+        <SubmitButton />
+      </EditFormProvider>,
+    )
+    fireEvent.change(screen.getByTestId('field-title'), { target: { value: 'b' } })
+    fireEvent.click(screen.getByTestId('btn-submit'))
+    await waitFor(() => expect(screen.getByTestId('probe-status').textContent).toBe('error'))
+    expect(screen.getByTestId('field-title').getAttribute('value')).toBe('b')
+  })
+})

--- a/src/admin/components/forms/EditFormProvider.tsx
+++ b/src/admin/components/forms/EditFormProvider.tsx
@@ -1,0 +1,344 @@
+'use client'
+
+/**
+ * @description
+ * <EditFormProvider> — the deep module owning every Layer 1 field's
+ * shared concerns: dirty state, validation aggregation, debounced
+ * autosave, undo/redo, and the submit lifecycle state machine.
+ *
+ * Field primitives don't manage their own value/dirty/error — they
+ * register against this provider and read/write through it. That keeps
+ * undo/redo, autosave, and submit consistent across every field type.
+ *
+ * @notes
+ * - Pure client module; no server-only imports. Provider lives at the
+ *   top of an edit view, child fields call `useEditFormField(name)`.
+ * - Optimistic submit: state flips to 'submitting' immediately,
+ *   resolves to 'success' or rolls back errors to 'error' if the
+ *   onSubmit promise rejects.
+ * - Validators are pure functions: `(value) => string | null`. They
+ *   run on every change so error state stays in sync.
+ */
+
+import * as React from 'react'
+
+export type FieldValidator = (value: unknown) => string | null
+
+export type SubmitStatus = 'idle' | 'submitting' | 'success' | 'error'
+
+export type EditFormState = {
+  /** Snapshot of the values when the form was opened or last saved. */
+  initialValues: Readonly<Record<string, unknown>>
+  /** Current values keyed by field name. */
+  values: Readonly<Record<string, unknown>>
+  /** Validation errors keyed by field name (null/undefined = valid). */
+  errors: Readonly<Record<string, string | null>>
+  /** Whether ANY field has diverged from `initialValues`. */
+  isDirty: boolean
+  /** Per-field dirty flags. */
+  dirty: Readonly<Record<string, boolean>>
+  /** Whether ALL registered fields are valid. */
+  isValid: boolean
+  /** Submit lifecycle state. */
+  submitStatus: SubmitStatus
+  /** Last submit error message, if any. */
+  submitError: string | null
+  /** Whether undo is available. */
+  canUndo: boolean
+  /** Whether redo is available. */
+  canRedo: boolean
+}
+
+export type EditFormActions = {
+  setFieldValue: (name: string, value: unknown) => void
+  setFieldError: (name: string, error: string | null) => void
+  registerField: (name: string, validator?: FieldValidator) => () => void
+  undo: () => void
+  redo: () => void
+  reset: () => void
+  submit: () => Promise<void>
+}
+
+export type EditFormContext = EditFormState & EditFormActions
+
+const Context = React.createContext<EditFormContext | null>(null)
+
+export type EditFormProviderProps = {
+  initialValues: Record<string, unknown>
+  /**
+   * Called when `submit()` runs OR after `autosaveDebounceMs` of inactivity
+   * if `autosave` is true. Should persist `values` and resolve on success.
+   */
+  onSubmit: (values: Record<string, unknown>) => Promise<void>
+  /** Enable debounced autosave on every value change. */
+  autosave?: boolean
+  /** Debounce window in ms. Default 800. */
+  autosaveDebounceMs?: number
+  /** Maximum undo history size. Default 50. */
+  maxHistory?: number
+  children: React.ReactNode
+}
+
+type HistoryEntry = {
+  values: Record<string, unknown>
+  errors: Record<string, string | null>
+}
+
+const computeIsDirty = (
+  values: Record<string, unknown>,
+  initialValues: Record<string, unknown>,
+): boolean => {
+  for (const key of Object.keys(values)) {
+    if (!Object.is(values[key], initialValues[key])) return true
+  }
+  for (const key of Object.keys(initialValues)) {
+    if (!(key in values)) return true
+  }
+  return false
+}
+
+const computeFieldDirty = (
+  values: Record<string, unknown>,
+  initialValues: Record<string, unknown>,
+): Record<string, boolean> => {
+  const out: Record<string, boolean> = {}
+  for (const key of Object.keys(values)) {
+    out[key] = !Object.is(values[key], initialValues[key])
+  }
+  return out
+}
+
+const computeIsValid = (errors: Record<string, string | null>): boolean =>
+  Object.values(errors).every((e) => !e)
+
+export const EditFormProvider: React.FC<EditFormProviderProps> = ({
+  initialValues,
+  onSubmit,
+  autosave = false,
+  autosaveDebounceMs = 800,
+  maxHistory = 50,
+  children,
+}) => {
+  const [values, setValues] = React.useState<Record<string, unknown>>(initialValues)
+  const [errors, setErrors] = React.useState<Record<string, string | null>>({})
+  const [submitStatus, setSubmitStatus] = React.useState<SubmitStatus>('idle')
+  const [submitError, setSubmitError] = React.useState<string | null>(null)
+  const [past, setPast] = React.useState<HistoryEntry[]>([])
+  const [future, setFuture] = React.useState<HistoryEntry[]>([])
+  const [savedInitial, setSavedInitial] = React.useState<Record<string, unknown>>(initialValues)
+
+  const validatorsRef = React.useRef<Record<string, FieldValidator>>({})
+  const autosaveTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const runValidator = React.useCallback((name: string, value: unknown): string | null => {
+    const v = validatorsRef.current[name]
+    return v ? v(value) : null
+  }, [])
+
+  const registerField = React.useCallback(
+    (name: string, validator?: FieldValidator): (() => void) => {
+      if (validator) {
+        validatorsRef.current[name] = validator
+        // Re-validate the current value with the new validator.
+        setErrors((prev) => ({ ...prev, [name]: validator(values[name]) }))
+      }
+      return () => {
+        delete validatorsRef.current[name]
+        setErrors((prev) => {
+          const next = { ...prev }
+          delete next[name]
+          return next
+        })
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    },
+    [],
+  )
+
+  const pushHistory = React.useCallback(
+    (entry: HistoryEntry) => {
+      setPast((prev) => {
+        const next = [...prev, entry]
+        return next.length > maxHistory ? next.slice(next.length - maxHistory) : next
+      })
+      setFuture([])
+    },
+    [maxHistory],
+  )
+
+  const setFieldValue = React.useCallback(
+    (name: string, value: unknown) => {
+      pushHistory({ values, errors })
+      setValues((prev) => ({ ...prev, [name]: value }))
+      setErrors((prev) => ({ ...prev, [name]: runValidator(name, value) }))
+    },
+    [values, errors, pushHistory, runValidator],
+  )
+
+  const setFieldError = React.useCallback((name: string, error: string | null) => {
+    setErrors((prev) => ({ ...prev, [name]: error }))
+  }, [])
+
+  const undo = React.useCallback(() => {
+    setPast((prevPast) => {
+      if (prevPast.length === 0) return prevPast
+      const previous = prevPast[prevPast.length - 1]
+      setFuture((f) => [...f, { values, errors }])
+      setValues(previous.values)
+      setErrors(previous.errors)
+      return prevPast.slice(0, -1)
+    })
+  }, [values, errors])
+
+  const redo = React.useCallback(() => {
+    setFuture((prevFuture) => {
+      if (prevFuture.length === 0) return prevFuture
+      const next = prevFuture[prevFuture.length - 1]
+      setPast((p) => [...p, { values, errors }])
+      setValues(next.values)
+      setErrors(next.errors)
+      return prevFuture.slice(0, -1)
+    })
+  }, [values, errors])
+
+  const reset = React.useCallback(() => {
+    setValues(savedInitial)
+    setErrors({})
+    setPast([])
+    setFuture([])
+    setSubmitStatus('idle')
+    setSubmitError(null)
+  }, [savedInitial])
+
+  const performSubmit = React.useCallback(
+    async (snapshot: Record<string, unknown>) => {
+      const errorsBefore = errors
+      setSubmitStatus('submitting')
+      setSubmitError(null)
+      try {
+        await onSubmit(snapshot)
+        setSavedInitial(snapshot)
+        setSubmitStatus('success')
+      } catch (err) {
+        // Rollback errors so any visual error markers from optimistic
+        // submission disappear. Keep `values` — user keeps their edits.
+        setErrors(errorsBefore)
+        setSubmitStatus('error')
+        setSubmitError(err instanceof Error ? err.message : String(err))
+      }
+    },
+    [onSubmit, errors],
+  )
+
+  const submit = React.useCallback(() => performSubmit(values), [performSubmit, values])
+
+  // Autosave: debounce a save when values change.
+  React.useEffect(() => {
+    if (!autosave) return
+    if (!computeIsDirty(values, savedInitial)) return
+    if (autosaveTimer.current) clearTimeout(autosaveTimer.current)
+    autosaveTimer.current = setTimeout(() => {
+      void performSubmit(values)
+    }, autosaveDebounceMs)
+    return () => {
+      if (autosaveTimer.current) clearTimeout(autosaveTimer.current)
+    }
+  }, [values, autosave, autosaveDebounceMs, savedInitial, performSubmit])
+
+  const isDirty = React.useMemo(() => computeIsDirty(values, savedInitial), [values, savedInitial])
+  const dirty = React.useMemo(
+    () => computeFieldDirty(values, savedInitial),
+    [values, savedInitial],
+  )
+  const isValid = React.useMemo(() => computeIsValid(errors), [errors])
+
+  const ctx = React.useMemo<EditFormContext>(
+    () => ({
+      initialValues: savedInitial,
+      values,
+      errors,
+      isDirty,
+      dirty,
+      isValid,
+      submitStatus,
+      submitError,
+      canUndo: past.length > 0,
+      canRedo: future.length > 0,
+      setFieldValue,
+      setFieldError,
+      registerField,
+      undo,
+      redo,
+      reset,
+      submit,
+    }),
+    [
+      savedInitial,
+      values,
+      errors,
+      isDirty,
+      dirty,
+      isValid,
+      submitStatus,
+      submitError,
+      past.length,
+      future.length,
+      setFieldValue,
+      setFieldError,
+      registerField,
+      undo,
+      redo,
+      reset,
+      submit,
+    ],
+  )
+
+  return <Context.Provider value={ctx}>{children}</Context.Provider>
+}
+
+/**
+ * Read the form context. Throws when called outside a provider — that's
+ * an authoring bug, not a runtime case.
+ */
+export const useEditForm = (): EditFormContext => {
+  const ctx = React.useContext(Context)
+  if (!ctx) {
+    throw new Error('useEditForm must be called inside <EditFormProvider>')
+  }
+  return ctx
+}
+
+export type EditFormFieldHandle = {
+  value: unknown
+  error: string | null
+  dirty: boolean
+  setValue: (value: unknown) => void
+}
+
+/**
+ * Field-level convenience hook: registers a validator on mount and
+ * returns the current value, error, dirty flag, and a setter scoped
+ * to this field. Layer 1 field primitives use this as their single
+ * source of truth.
+ */
+export const useEditFormField = (
+  name: string,
+  validator?: FieldValidator,
+): EditFormFieldHandle => {
+  const ctx = useEditForm()
+  const validatorRef = React.useRef(validator)
+  validatorRef.current = validator
+
+  React.useEffect(() => {
+    return ctx.registerField(name, validatorRef.current)
+    // Re-register only when the field name changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [name, ctx.registerField])
+
+  return {
+    value: ctx.values[name],
+    error: ctx.errors[name] ?? null,
+    dirty: !!ctx.dirty[name],
+    setValue: (value: unknown) => ctx.setFieldValue(name, value),
+  }
+}

--- a/src/admin/components/forms/EditFormShowcase.tsx
+++ b/src/admin/components/forms/EditFormShowcase.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+/**
+ * @description
+ * Mock field consumer that exercises every <EditFormProvider> surface
+ * so reviewers can poke at dirty/validation/undo/submit/autosave
+ * behavior without any real backend. The same harness is reused by
+ * Storybook stories when the corresponding stories file lands.
+ */
+
+import * as React from 'react'
+
+import {
+  EditFormProvider,
+  useEditForm,
+  useEditFormField,
+} from './EditFormProvider'
+
+const MockTextField: React.FC<{ name: string; label: string; required?: boolean }> = ({
+  name,
+  label,
+  required,
+}) => {
+  const validator = required
+    ? (value: unknown) => (typeof value === 'string' && value.length > 0 ? null : 'Required')
+    : undefined
+  const { value, error, dirty, setValue } = useEditFormField(name, validator)
+
+  return (
+    <label
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+        fontSize: 13,
+        color: 'var(--text-primary)',
+      }}
+    >
+      <span style={{ fontWeight: 500 }}>
+        {label}
+        {required ? ' *' : ''}
+        {dirty ? (
+          <em style={{ marginLeft: 6, color: 'var(--workflow-review)', fontStyle: 'normal' }}>
+            (modified)
+          </em>
+        ) : null}
+      </span>
+      <input
+        type="text"
+        value={String(value ?? '')}
+        onChange={(e) => setValue(e.target.value)}
+        style={{
+          height: 32,
+          padding: '0 8px',
+          border: `1px solid ${error ? 'var(--workflow-revision)' : 'var(--border-default)'}`,
+          borderRadius: 4,
+          background: 'var(--surface-page)',
+          fontSize: 13,
+          fontFamily: 'inherit',
+        }}
+      />
+      {error && (
+        <span style={{ color: 'var(--workflow-revision)', fontSize: 12 }}>{error}</span>
+      )}
+    </label>
+  )
+}
+
+const FormToolbar: React.FC = () => {
+  const { isDirty, isValid, submitStatus, submitError, canUndo, canRedo, undo, redo, reset, submit } =
+    useEditForm()
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        gap: 8,
+        padding: 12,
+        borderTop: '1px solid var(--border-default)',
+        marginTop: 12,
+      }}
+    >
+      <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+        {submitStatus === 'submitting'
+          ? 'Saving…'
+          : submitStatus === 'success'
+            ? 'Saved'
+            : submitStatus === 'error'
+              ? `Error: ${submitError ?? 'unknown'}`
+              : isDirty
+                ? 'Unsaved changes'
+                : 'No changes'}
+      </span>
+      <div style={{ flex: 1 }} />
+      <button type="button" onClick={undo} disabled={!canUndo}>
+        Undo
+      </button>
+      <button type="button" onClick={redo} disabled={!canRedo}>
+        Redo
+      </button>
+      <button type="button" onClick={reset} disabled={!isDirty}>
+        Reset
+      </button>
+      <button
+        type="button"
+        onClick={() => void submit()}
+        disabled={!isDirty || !isValid || submitStatus === 'submitting'}
+      >
+        Save Draft
+      </button>
+    </div>
+  )
+}
+
+export const EditFormShowcase: React.FC = () => (
+  <EditFormProvider
+    initialValues={{ title: '', summary: '' }}
+    onSubmit={async (values) => {
+      // Simulate latency so the lifecycle states are observable.
+      await new Promise((r) => setTimeout(r, 600))
+      // eslint-disable-next-line no-console
+      console.log('[EditFormShowcase] saved', values)
+    }}
+  >
+    <div
+      style={{
+        padding: 16,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12,
+        maxWidth: 480,
+        backgroundColor: 'var(--surface-page)',
+      }}
+    >
+      <h1 style={{ margin: 0, fontSize: 18 }}>Edit form harness</h1>
+      <MockTextField name="title" label="Title" required />
+      <MockTextField name="summary" label="Summary" />
+      <FormToolbar />
+    </div>
+  </EditFormProvider>
+)
+
+export default EditFormShowcase


### PR DESCRIPTION
## Summary
Deep module that owns every Layer 1 field's shared concerns. Field primitives don't manage their own value/dirty/error — they register through this provider and flow through one source of truth.

**Surfaces:**
- Dirty tracking (per-field + aggregated `isDirty`)
- Validation aggregation (per-field validators + aggregated `isValid`)
- Debounced autosave (`autosave` + `autosaveDebounceMs`, default 800ms)
- Undo/redo history (default cap: 50 entries; redo stack clears on new edit)
- Submit lifecycle state machine: `idle → submitting → success | error`
- Optimistic submit: state flips immediately; rolls back to `error` on rejection while preserving the user's edits

**Hooks exposed:**
- `useEditForm()` — full state + actions
- `useEditFormField(name, validator?)` — convenience hook for primitive fields

## Acceptance criteria
- [x] Vitest coverage: dirty tracking, validation aggregation, autosave debouncing, undo/redo correctness, submit lifecycle (9 tests, all passing)
- [x] Mock field consumer demonstrates context wiring (`EditFormShowcase`)
- [x] Optimistic submit with rollback on error
- [x] `tsc --noEmit` clean for new files (pre-existing errors in `(frontend)/[locale]/(frontend)/layout.tsx` predate this PR — Next 16 `params: Promise<...>` migration is its own work item)

## Test plan
- [x] `npx vitest run src/admin/components/forms/EditFormProvider.test.tsx` — 9/9 pass

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)