### PR TITLE
feat(admin-shell): <CheckboxField> + <RadioField> + <ToggleField> primitives

### DIFF
--- a/src/admin/components/fields/BooleanFields.test.tsx
+++ b/src/admin/components/fields/BooleanFields.test.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { EditFormProvider } from '../forms/EditFormProvider'
+import { CheckboxField, RadioField, ToggleField } from './BooleanFields'
+
+const wrap = (
+  ui: React.ReactNode,
+  initial: Record<string, unknown>,
+) => (
+  <EditFormProvider initialValues={initial} onSubmit={async () => {}}>
+    {ui}
+  </EditFormProvider>
+)
+
+describe('<CheckboxField>', () => {
+  it('reflects the bound boolean value', () => {
+    render(wrap(<CheckboxField name="agree" label="Agree" caption="OK" />, { agree: true }))
+    expect((screen.getByLabelText(/Agree/) as HTMLInputElement).checked).toBe(true)
+  })
+
+  it('toggles on click', () => {
+    render(wrap(<CheckboxField name="agree" label="Agree" />, { agree: false }))
+    fireEvent.click(screen.getByLabelText(/Agree/))
+    expect((screen.getByLabelText(/Agree/) as HTMLInputElement).checked).toBe(true)
+  })
+
+  it('flags required when unchecked', () => {
+    render(wrap(<CheckboxField name="agree" label="Agree" required />, { agree: false }))
+    expect(screen.getByText('Required')).toBeInTheDocument()
+  })
+
+  it('disables when locked by another user', () => {
+    render(
+      wrap(<CheckboxField name="agree" label="Agree" lock="locked-by-other" />, {
+        agree: true,
+      }),
+    )
+    expect((screen.getByLabelText(/Agree/) as HTMLInputElement).disabled).toBe(true)
+  })
+})
+
+describe('<ToggleField>', () => {
+  it('renders with role=switch and toggles', () => {
+    render(wrap(<ToggleField name="on" label="On" />, { on: false }))
+    const sw = screen.getByRole('switch') as HTMLInputElement
+    expect(sw.checked).toBe(false)
+    fireEvent.click(sw)
+    expect(sw.checked).toBe(true)
+  })
+})
+
+describe('<RadioField>', () => {
+  const OPTIONS = [
+    { value: 'a', label: 'Alpha' },
+    { value: 'b', label: 'Beta' },
+  ]
+
+  it('renders one input per option, selects the bound value', () => {
+    render(
+      wrap(<RadioField name="pick" label="Pick" options={OPTIONS} />, { pick: 'b' }),
+    )
+    expect((screen.getByLabelText('Alpha') as HTMLInputElement).checked).toBe(false)
+    expect((screen.getByLabelText('Beta') as HTMLInputElement).checked).toBe(true)
+  })
+
+  it('updates the bound value when a different option is picked', () => {
+    render(
+      wrap(<RadioField name="pick" label="Pick" options={OPTIONS} />, { pick: 'a' }),
+    )
+    fireEvent.click(screen.getByLabelText('Beta'))
+    expect((screen.getByLabelText('Beta') as HTMLInputElement).checked).toBe(true)
+  })
+
+  it('flags required when nothing selected', () => {
+    render(
+      wrap(<RadioField name="pick" label="Pick" required options={OPTIONS} />, {
+        pick: null,
+      }),
+    )
+    expect(screen.getByText('Required')).toBeInTheDocument()
+  })
+})

--- a/src/admin/components/fields/BooleanFields.tsx
+++ b/src/admin/components/fields/BooleanFields.tsx
@@ -1,0 +1,244 @@
+'use client'
+
+/**
+ * @description
+ * Three boolean / choice primitives sharing the EditFormField hook
+ * + FieldShell chrome:
+ * - <CheckboxField>: single boolean checkbox
+ * - <ToggleField>: visual switch backed by a checkbox
+ * - <RadioField>: exclusive option group, stores `string | null`
+ *
+ * @notes
+ * - WCAG 2.2 §2.5.8 target size: every interactive control is ≥24×24px.
+ * - Checkbox + Toggle store boolean. Radio stores the chosen option's
+ *   `value` field (or null when none chosen).
+ */
+
+import * as React from 'react'
+
+import { useEditFormField, type FieldValidator } from '../forms/EditFormProvider'
+import { FieldShell } from './FieldShell'
+import type { FieldCommonProps } from './field-types'
+
+const requiredBoolean: FieldValidator = (v) => (v === true ? null : 'Required')
+const requiredString: FieldValidator = (v) =>
+  typeof v === 'string' && v.length > 0 ? null : 'Required'
+
+export type CheckboxFieldProps = FieldCommonProps & {
+  /** Inline copy beside the checkbox (the "label" prop handles the field title). */
+  caption?: string
+}
+
+export const CheckboxField: React.FC<CheckboxFieldProps> = ({
+  name,
+  label,
+  description,
+  required,
+  lock = 'unlocked',
+  readOnly,
+  caption,
+}) => {
+  const { value, error, dirty, setValue } = useEditFormField(
+    name,
+    required ? requiredBoolean : undefined,
+  )
+  const isReadOnly = readOnly || lock === 'locked-by-other'
+  const checked = value === true
+
+  return (
+    <FieldShell
+      name={name}
+      label={label}
+      description={description}
+      required={required}
+      lock={lock}
+      error={error}
+      dirty={dirty}
+    >
+      <label
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 8,
+          minHeight: 24,
+          cursor: isReadOnly ? 'not-allowed' : 'pointer',
+          color: isReadOnly ? 'var(--text-muted)' : 'var(--text-primary)',
+        }}
+      >
+        <input
+          id={name}
+          name={name}
+          type="checkbox"
+          checked={checked}
+          disabled={isReadOnly}
+          onChange={(e) => setValue(e.target.checked)}
+          style={{ width: 18, height: 18, cursor: isReadOnly ? 'not-allowed' : 'pointer' }}
+        />
+        {caption && <span style={{ fontSize: 13 }}>{caption}</span>}
+      </label>
+    </FieldShell>
+  )
+}
+
+export type ToggleFieldProps = CheckboxFieldProps
+
+export const ToggleField: React.FC<ToggleFieldProps> = ({
+  name,
+  label,
+  description,
+  required,
+  lock = 'unlocked',
+  readOnly,
+  caption,
+}) => {
+  const { value, error, dirty, setValue } = useEditFormField(
+    name,
+    required ? requiredBoolean : undefined,
+  )
+  const isReadOnly = readOnly || lock === 'locked-by-other'
+  const checked = value === true
+
+  return (
+    <FieldShell
+      name={name}
+      label={label}
+      description={description}
+      required={required}
+      lock={lock}
+      error={error}
+      dirty={dirty}
+    >
+      <label
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 10,
+          minHeight: 24,
+          cursor: isReadOnly ? 'not-allowed' : 'pointer',
+          color: isReadOnly ? 'var(--text-muted)' : 'var(--text-primary)',
+        }}
+      >
+        <input
+          id={name}
+          name={name}
+          type="checkbox"
+          role="switch"
+          checked={checked}
+          aria-checked={checked}
+          disabled={isReadOnly}
+          onChange={(e) => setValue(e.target.checked)}
+          style={{
+            // Hide the native checkbox visually but keep it accessible.
+            position: 'absolute',
+            width: 1,
+            height: 1,
+            padding: 0,
+            margin: -1,
+            overflow: 'hidden',
+            clipPath: 'inset(50%)',
+            border: 0,
+          }}
+        />
+        <span
+          aria-hidden
+          style={{
+            position: 'relative',
+            display: 'inline-block',
+            width: 36,
+            height: 20,
+            background: checked ? 'var(--brand-fras)' : 'var(--surface-sunken)',
+            borderRadius: 10,
+            transition: 'background 100ms ease',
+          }}
+        >
+          <span
+            style={{
+              position: 'absolute',
+              top: 2,
+              left: checked ? 18 : 2,
+              width: 16,
+              height: 16,
+              borderRadius: '50%',
+              background: 'var(--surface-page)',
+              boxShadow: '0 1px 2px rgba(0,0,0,0.2)',
+              transition: 'left 100ms ease',
+            }}
+          />
+        </span>
+        {caption && <span style={{ fontSize: 13 }}>{caption}</span>}
+      </label>
+    </FieldShell>
+  )
+}
+
+export type RadioOption = {
+  value: string
+  label: string
+}
+
+export type RadioFieldProps = FieldCommonProps & {
+  options: RadioOption[]
+}
+
+export const RadioField: React.FC<RadioFieldProps> = ({
+  name,
+  label,
+  description,
+  required,
+  lock = 'unlocked',
+  readOnly,
+  options,
+}) => {
+  const { value, error, dirty, setValue } = useEditFormField(
+    name,
+    required ? requiredString : undefined,
+  )
+  const isReadOnly = readOnly || lock === 'locked-by-other'
+  const selected = typeof value === 'string' ? value : null
+
+  return (
+    <FieldShell
+      name={name}
+      label={label}
+      description={description}
+      required={required}
+      lock={lock}
+      error={error}
+      dirty={dirty}
+    >
+      <div role="radiogroup" aria-labelledby={name}>
+        {options.map((opt) => {
+          const id = `${name}-${opt.value}`
+          const checked = selected === opt.value
+          return (
+            <label
+              key={opt.value}
+              htmlFor={id}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 8,
+                marginRight: 16,
+                minHeight: 24,
+                cursor: isReadOnly ? 'not-allowed' : 'pointer',
+                color: isReadOnly ? 'var(--text-muted)' : 'var(--text-primary)',
+              }}
+            >
+              <input
+                id={id}
+                type="radio"
+                name={name}
+                value={opt.value}
+                checked={checked}
+                disabled={isReadOnly}
+                onChange={() => setValue(opt.value)}
+                style={{ width: 18, height: 18, cursor: isReadOnly ? 'not-allowed' : 'pointer' }}
+              />
+              <span style={{ fontSize: 13 }}>{opt.label}</span>
+            </label>
+          )
+        })}
+      </div>
+    </FieldShell>
+  )
+}


### PR DESCRIPTION
## Summary
Three boolean / choice primitives in one file (they share the same `useEditFormField` + `<FieldShell>` pattern; one file keeps surface area small).

- `<CheckboxField>` — native checkbox, stores boolean
- `<ToggleField>` — visual switch backed by `<input type="checkbox" role="switch">`. Native input visually hidden but accessible / focusable.
- `<RadioField>` — exclusive group, stores chosen value (or null)

WCAG 2.2 §2.5.8 target size: ≥24×24 clickable label area on every control.

## Acceptance criteria
- [x] Vitest: each handles checked/unchecked, group selection (radio), validation — 8/8 passing
- [x] WCAG 2.2 AA target-size compliance (≥24×24 hit areas)
- [x] `tsc --noEmit` clean for new files

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)