### PR TITLE
feat(admin-shell): <TabsField> + <GroupField> + <RowField> layout primitives

### DIFF
--- a/src/admin/components/fields/LayoutPrimitives.test.tsx
+++ b/src/admin/components/fields/LayoutPrimitives.test.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { GroupField, RowField, TabsField } from './LayoutPrimitives'
+
+describe('<TabsField>', () => {
+  const TABS = [
+    { id: 'a', label: 'A', content: <div>panel-a</div> },
+    { id: 'b', label: 'B', content: <div>panel-b</div> },
+  ]
+
+  it('renders the first tab active by default', () => {
+    render(<TabsField tabs={TABS} />)
+    expect(screen.getByText('panel-a')).toBeInTheDocument()
+    expect(screen.queryByText('panel-b')).not.toBeInTheDocument()
+  })
+
+  it('switches active tab on click', () => {
+    render(<TabsField tabs={TABS} />)
+    fireEvent.click(screen.getByRole('tab', { name: 'B' }))
+    expect(screen.getByText('panel-b')).toBeInTheDocument()
+    expect(screen.queryByText('panel-a')).not.toBeInTheDocument()
+  })
+
+  it('respects controlled activeId', () => {
+    const { rerender } = render(<TabsField tabs={TABS} activeId="a" />)
+    expect(screen.getByText('panel-a')).toBeInTheDocument()
+    rerender(<TabsField tabs={TABS} activeId="b" />)
+    expect(screen.getByText('panel-b')).toBeInTheDocument()
+  })
+})
+
+describe('<GroupField>', () => {
+  it('renders open by default with children visible', () => {
+    render(
+      <GroupField label="Section">
+        <p>inner</p>
+      </GroupField>,
+    )
+    expect(screen.getByText('inner')).toBeInTheDocument()
+  })
+
+  it('collapses on click', () => {
+    render(
+      <GroupField label="Section">
+        <p>inner</p>
+      </GroupField>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Section/ }))
+    expect(screen.queryByText('inner')).not.toBeInTheDocument()
+  })
+
+  it('respects defaultOpen=false', () => {
+    render(
+      <GroupField label="Section" defaultOpen={false}>
+        <p>inner</p>
+      </GroupField>,
+    )
+    expect(screen.queryByText('inner')).not.toBeInTheDocument()
+  })
+})
+
+describe('<RowField>', () => {
+  it('renders all children', () => {
+    render(
+      <RowField>
+        <span>one</span>
+        <span>two</span>
+        <span>three</span>
+      </RowField>,
+    )
+    expect(screen.getByText('one')).toBeInTheDocument()
+    expect(screen.getByText('two')).toBeInTheDocument()
+    expect(screen.getByText('three')).toBeInTheDocument()
+  })
+})

--- a/src/admin/components/fields/LayoutPrimitives.tsx
+++ b/src/admin/components/fields/LayoutPrimitives.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+/**
+ * @description
+ * Three Payload-style layout container primitives. These don't bind
+ * to form values themselves — they group child fields visually.
+ *
+ * - <TabsField>: tabbed grouping with controlled or uncontrolled state
+ * - <GroupField>: collapsible group with header
+ * - <RowField>: horizontal row layout for multi-field rows
+ */
+
+import * as React from 'react'
+
+export type Tab = {
+  id: string
+  label: string
+  content: React.ReactNode
+}
+
+export type TabsFieldProps = {
+  tabs: Tab[]
+  activeId?: string
+  defaultActiveId?: string
+  onChange?: (id: string) => void
+  /** Identifier used for ARIA wiring. */
+  ariaLabel?: string
+}
+
+export const TabsField: React.FC<TabsFieldProps> = ({
+  tabs,
+  activeId,
+  defaultActiveId,
+  onChange,
+  ariaLabel = 'tabs',
+}) => {
+  const [internalActive, setInternalActive] = React.useState<string>(
+    defaultActiveId ?? tabs[0]?.id ?? '',
+  )
+  const active = activeId ?? internalActive
+  const handleClick = (id: string) => {
+    if (activeId === undefined) setInternalActive(id)
+    onChange?.(id)
+  }
+
+  return (
+    <div data-tabs={ariaLabel}>
+      <div
+        role="tablist"
+        aria-label={ariaLabel}
+        style={{
+          display: 'flex',
+          gap: 4,
+          borderBottom: '1px solid var(--border-default)',
+          marginBottom: 12,
+        }}
+      >
+        {tabs.map((t) => {
+          const selected = t.id === active
+          return (
+            <button
+              key={t.id}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              aria-controls={`tabpanel-${t.id}`}
+              id={`tab-${t.id}`}
+              onClick={() => handleClick(t.id)}
+              style={{
+                padding: '8px 12px',
+                background: 'transparent',
+                border: 'none',
+                borderBottom: selected
+                  ? '2px solid var(--brand-fras)'
+                  : '2px solid transparent',
+                color: selected ? 'var(--brand-fras)' : 'var(--text-secondary)',
+                fontWeight: selected ? 600 : 500,
+                fontSize: 13,
+                fontFamily: 'inherit',
+                cursor: 'pointer',
+                marginBottom: -1,
+              }}
+            >
+              {t.label}
+            </button>
+          )
+        })}
+      </div>
+      {tabs.map((t) => (
+        <div
+          key={t.id}
+          role="tabpanel"
+          id={`tabpanel-${t.id}`}
+          aria-labelledby={`tab-${t.id}`}
+          hidden={t.id !== active}
+        >
+          {t.id === active ? t.content : null}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export type GroupFieldProps = {
+  label: string
+  children: React.ReactNode
+  defaultOpen?: boolean
+  description?: string
+}
+
+export const GroupField: React.FC<GroupFieldProps> = ({
+  label,
+  children,
+  defaultOpen = true,
+  description,
+}) => {
+  const [open, setOpen] = React.useState(defaultOpen)
+  return (
+    <fieldset
+      style={{
+        margin: 0,
+        padding: 0,
+        border: '1px solid var(--border-default)',
+        borderRadius: 6,
+        background: 'var(--surface-page)',
+      }}
+    >
+      <legend style={{ padding: 0 }}>
+        <button
+          type="button"
+          aria-expanded={open}
+          onClick={() => setOpen((o) => !o)}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '6px 10px',
+            background: 'var(--surface-elevated)',
+            border: '1px solid var(--border-default)',
+            borderRadius: 4,
+            color: 'var(--text-primary)',
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+          }}
+        >
+          <span aria-hidden style={{ fontFamily: 'ui-monospace, monospace' }}>
+            {open ? '▾' : '▸'}
+          </span>
+          {label}
+        </button>
+      </legend>
+      {open && (
+        <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {description && (
+            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>{description}</span>
+          )}
+          {children}
+        </div>
+      )}
+    </fieldset>
+  )
+}
+
+export type RowFieldProps = {
+  children: React.ReactNode
+  gap?: number
+}
+
+export const RowField: React.FC<RowFieldProps> = ({ children, gap = 12 }) => (
+  <div
+    style={{
+      display: 'flex',
+      gap,
+      alignItems: 'flex-start',
+      flexWrap: 'wrap',
+    }}
+  >
+    {React.Children.map(children, (child, i) => (
+      <div key={i} style={{ flex: 1, minWidth: 180 }}>
+        {child}
+      </div>
+    ))}
+  </div>
+)


### PR DESCRIPTION
## Summary
Three Payload-style layout containers. None bind to form values themselves — they just group child fields visually.

- `<TabsField>` — tablist + panels. Controlled (`activeId`) or uncontrolled (`defaultActiveId`). ARIA wired (`role=tablist`, `aria-selected`, `aria-controls`).
- `<GroupField>` — collapsible `<fieldset>`/`<legend>` with expand button.
- `<RowField>` — flex row with even-width children that wrap on narrow viewports.

## Acceptance criteria
- [x] Vitest: each renders children, tab switching, collapsible group — 7/7 passing
- [x] `tsc --noEmit` clean for new files

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)