### PR TITLE
fix(admin-shell): pull AdminShell out of the layout to stop double-chrome + pre-login leak

### DIFF
--- a/src/admin/lib/auth-gate.ts
+++ b/src/admin/lib/auth-gate.ts
@@ -18,18 +18,30 @@ import config from '@payload-config'
 
 import type { AdminUser } from '../components/shell/UserContext'
 
-export const requireAdminUser = async (): Promise<AdminUser> => {
+/**
+ * Resolves the current admin user without redirecting. Returns null
+ * when the request is unauthenticated. Use this at the layout level
+ * where some children are public (e.g. /admin/login).
+ */
+export const getAdminUser = async (): Promise<AdminUser | null> => {
   const payload = await getPayload({ config })
   const headers = await nextHeaders()
   const { user } = await payload.auth({ headers })
-
-  if (!user) {
-    redirect('/admin/login')
-  }
-
+  if (!user) return null
   return {
     id: user.id,
     email: user.email ?? '',
     collection: user.collection,
   }
+}
+
+/**
+ * Hard-gate variant: redirects to /admin/login when the request is
+ * unauthenticated. Use this at the page level for routes that must
+ * never render to unauthenticated users.
+ */
+export const requireAdminUser = async (): Promise<AdminUser> => {
+  const user = await getAdminUser()
+  if (!user) redirect('/admin/login')
+  return user
 }

--- a/src/app/(payload)/admin/layout.tsx
+++ b/src/app/(payload)/admin/layout.tsx
@@ -1,27 +1,22 @@
 /**
  * @description
- * Layout for `/admin/*` routes. Mounts `<AdminShell>` as the outer chrome.
- * Custom routes (e.g. `/admin/tree`) render inside the shell. Payload's
- * existing `[[...segments]]` catch-all still resolves anything else under
- * `/admin/*` (transitional — Layer 8 retires it).
+ * Layout for `/admin/*` routes. Pure passthrough during the transitional
+ * period — Payload's stock catch-all (`[[...segments]]`) renders its
+ * own chrome via `(payload)/layout.tsx → <RootLayout>`, and v2 custom
+ * routes opt into `<AdminShell>` themselves.
  *
  * @notes
- * - This layout sits *inside* Payload's `(payload)/layout.tsx → <RootLayout>`,
- *   so Payload's stock pages (rendered by the catch-all) will visually
- *   nest within `<AdminShell>`. The doubled chrome is intentional for the
- *   transitional period and disappears once each surface migrates to a
- *   native edit view.
- * - Slot props left empty here are filled by sibling Layer 0 issues
- *   (#6 left tree, #7 action bar, #8 language switcher, #10 auth bridge).
+ * - Wrapping every /admin/* route with AdminShell here would render
+ *   AdminShell's chrome alongside Payload's stock CustomNav + dashboard,
+ *   which produces a three-column nav collision and leaks tree contents
+ *   to unauthenticated users on /admin/login.
+ * - Layer 8's cutover retires Payload's catch-all, at which point
+ *   AdminShell is promoted back to the layout level as the universal
+ *   chrome. Until then, this layout stays a passthrough.
  */
 
 import * as React from 'react'
 
-import { AdminShell } from '../../../admin/components/shell/AdminShell'
-import { TreeSpineDefault } from '../../../admin/components/tree/TreeSpineDefault'
-
-const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <AdminShell leftRail={<TreeSpineDefault />}>{children}</AdminShell>
-)
+const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => <>{children}</>
 
 export default Layout

--- a/src/app/(payload)/admin/tree/page.tsx
+++ b/src/app/(payload)/admin/tree/page.tsx
@@ -1,20 +1,22 @@
 /**
  * @description
  * `/admin/tree` — first custom route inside the new `<AdminShell>`.
- * Server-gates via `requireAdminUser()` (see #10) and exposes the
- * resolved user to client descendants via `<UserProvider>`. Placeholder
- * workspace until #6 lands the persistent left tree spine.
+ * Hard-gates via `requireAdminUser()` (redirects unauthenticated to
+ * /admin/login) and explicitly wraps the workspace with AdminShell +
+ * UserProvider + the persistent left tree spine.
  *
  * @notes
- * - Auth gate is opt-in per route (not layout-wide) so we don't break
- *   the unauthenticated entry to Payload's stock `/admin/login` page,
- *   which still resolves through the catch-all in this transitional
- *   period.
+ * - AdminShell is mounted at the page level (not the layout level)
+ *   during the v1↔v2 transitional period so Payload's stock chrome
+ *   isn't double-rendered alongside ours. Layer 8 promotes AdminShell
+ *   back to the layout once Payload's catch-all is retired.
  */
 
 import * as React from 'react'
 
+import { AdminShell } from '../../../../admin/components/shell/AdminShell'
 import { UserProvider } from '../../../../admin/components/shell/UserContext'
+import { TreeSpineDefault } from '../../../../admin/components/tree/TreeSpineDefault'
 import { requireAdminUser } from '../../../../admin/lib/auth-gate'
 
 const Page = async () => {
@@ -22,13 +24,15 @@ const Page = async () => {
 
   return (
     <UserProvider user={user}>
-      <div style={{ padding: 24, color: 'var(--text-primary)' }}>
-        <h1 style={{ marginTop: 0, fontSize: 22 }}>Content tree</h1>
-        <p style={{ color: 'var(--text-muted)' }}>
-          Signed in as <strong>{user.email}</strong>. The persistent left tree spine and inline
-          tree workspace land in #6.
-        </p>
-      </div>
+      <AdminShell leftRail={<TreeSpineDefault />}>
+        <div style={{ padding: 24, color: 'var(--text-primary)' }}>
+          <h1 style={{ marginTop: 0, fontSize: 22 }}>Content tree</h1>
+          <p style={{ color: 'var(--text-muted)' }}>
+            Signed in as <strong>{user.email}</strong>. The persistent left tree spine
+            is active in the rail. Native tree workspace lands in a follow-on.
+          </p>
+        </div>
+      </AdminShell>
     </UserProvider>
   )
 }


### PR DESCRIPTION
## Bug
AdminShell at the layout level wrapped **every** /admin/\* route, which produced two real bugs caught during smoke testing:

1. **Pre-login content leak** — /admin/login rendered the tree spine alongside Payload's login form. Unauthenticated users could read the board / news / project navigation hierarchy before authenticating.
2. **Triple-nav collision** — /admin (Payload's dashboard) and any other catch-all-served route rendered AdminShell's left rail + Payload's stock CustomNav side-by-side. Two separate navigation systems competing for the same viewport.

## Fix
- \`(payload)/admin/layout.tsx\` is now a pure passthrough during the v1↔v2 transitional period.
- v2 custom routes opt into AdminShell **explicitly** at the page level. \`/admin/tree\` wraps its workspace with \`<AdminShell>\` + \`<UserProvider>\` after \`requireAdminUser()\` resolves the user.
- Layer 8's cutover will promote AdminShell back to layout-level once Payload's catch-all is retired.
- Added \`getAdminUser()\` — non-redirecting variant of \`requireAdminUser()\` — so future layout-level conditional wrappers don't have to redirect public routes.

## Verification
End-to-end smoke against http://localhost:3000:

| Route | State | Expected | Actual |
|---|---|---|---|
| \`/admin/login\` | logged out | bare Payload login, no tree leak | ✓ |
| \`/admin\` | logged in | Payload dashboard only, no doubled chrome | ✓ |
| \`/admin/tree\` | logged in | AdminShell + tree spine, bare workspace | ✓ |

- \`npx vitest run\` — 113/113 pass
- \`npm run build\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)