### PR TITLE
fix(frontend): wire Lexical serializer for project Summary + Key Proposals

### DIFF
--- a/src/app/(frontend)/[locale]/(frontend)/active-projects/[board]/[project-slug]/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/active-projects/[board]/[project-slug]/page.tsx
@@ -25,6 +25,7 @@ import { notFound } from 'next/navigation'
 import { withLocaleMetadata } from '@/lib/i18n-metadata'
 import { Breadcrumb } from '@/components/layout/Breadcrumb'
 import { ProjectTimeline } from '@/components/board/ProjectTimeline'
+import { RichText } from '@/components/RichText'
 import {
   SectionNav,
   QuickActions,
@@ -157,11 +158,10 @@ export default async function ProjectDetailPage({ params }: PageProps) {
           {project.summary && (
             <section data-testid="section-summary">
               <h2 className="mb-4 text-xl font-bold text-text-heading">Summary</h2>
-              <div className="prose max-w-none text-text-primary">
-                <p className="text-text-muted">
-                  Rich text content will render here when Lexical serializer is configured.
-                </p>
-              </div>
+              <RichText
+                content={project.summary}
+                className="prose max-w-none text-text-primary"
+              />
             </section>
           )}
 
@@ -169,11 +169,10 @@ export default async function ProjectDetailPage({ params }: PageProps) {
           {project.key_proposals && (
             <section data-testid="section-key-proposals">
               <h2 className="mb-4 text-xl font-bold text-text-heading">Key Proposals</h2>
-              <div className="prose max-w-none text-text-primary">
-                <p className="text-text-muted">
-                  Rich text content will render here when Lexical serializer is configured.
-                </p>
-              </div>
+              <RichText
+                content={project.key_proposals}
+                className="prose max-w-none text-text-primary"
+              />
             </section>
           )}
 

--- a/src/components/RichText.test.tsx
+++ b/src/components/RichText.test.tsx
@@ -1,0 +1,96 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { RichText } from './RichText'
+
+const validDoc = {
+  root: {
+    type: 'root',
+    format: '',
+    indent: 0,
+    version: 1,
+    direction: 'ltr',
+    children: [
+      {
+        type: 'paragraph',
+        version: 1,
+        format: '',
+        indent: 0,
+        direction: 'ltr',
+        textFormat: 0,
+        textStyle: '',
+        children: [
+          {
+            type: 'text',
+            version: 1,
+            text: 'Hello world',
+            format: 0,
+            mode: 'normal',
+            style: '',
+            detail: 0,
+          },
+        ],
+      },
+    ],
+  },
+} as const
+
+const emptyDoc = {
+  root: {
+    type: 'root',
+    format: '',
+    indent: 0,
+    version: 1,
+    direction: 'ltr',
+    children: [],
+  },
+} as const
+
+const unknownNodeDoc = {
+  root: {
+    type: 'root',
+    format: '',
+    indent: 0,
+    version: 1,
+    direction: 'ltr',
+    children: [
+      {
+        type: 'something-unknown-node-type',
+        version: 1,
+      },
+    ],
+  },
+} as const
+
+describe('<RichText>', () => {
+  it('renders text from a valid Lexical document', () => {
+    const { container } = render(<RichText content={validDoc} />)
+    expect(container.textContent).toContain('Hello world')
+  })
+
+  it('renders nothing when content is null', () => {
+    const { container } = render(<RichText content={null} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when content is undefined', () => {
+    const { container } = render(<RichText content={undefined} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing for an empty Lexical document', () => {
+    const { container } = render(<RichText content={emptyDoc} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('does not throw on unknown node types', () => {
+    expect(() => render(<RichText content={unknownNodeDoc} />)).not.toThrow()
+  })
+
+  it('applies the className to the wrapper', () => {
+    const { container } = render(
+      <RichText content={validDoc} className="prose" />,
+    )
+    expect((container.firstChild as HTMLElement).className).toBe('prose')
+  })
+})

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -22,6 +22,11 @@ type RichTextProps = {
 export function RichText({ content, className }: RichTextProps) {
   if (!content) return null
 
+  const root = (content as { root?: { children?: unknown[] } }).root
+  if (!root || !Array.isArray(root.children) || root.children.length === 0) {
+    return null
+  }
+
   return (
     <div className={className}>
       <PayloadRichText data={content as SerializedEditorState} />


### PR DESCRIPTION
## Summary

- Replaces the literal placeholder string ("Rich text content will render here when Lexical serializer is configured.") on the project detail page with the existing `<RichText>` wrapper around `@payloadcms/richtext-lexical/react`
- Hardens `<RichText>` to render nothing for empty Lexical documents (root with no children)
- Adds unit tests covering valid docs, null/undefined, empty docs, and unknown node types

Closes #79
Tracked under #101

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 119 / 119 pass (incl. 6 new RichText tests)
- [x] `npm run build` succeeds
- [ ] Manual: `/en/active-projects/<board>/<slug>` Summary + Key Proposals render real CMS content (no placeholder string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)