### PR TITLE
fix(frontend): contact form transition + persistence hardening

### DIFF
--- a/src/actions/contact.test.ts
+++ b/src/actions/contact.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createMock, verifyRecaptchaMock } = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  verifyRecaptchaMock: vi.fn(),
+}))
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn(async () => ({ create: createMock })),
+}))
+
+vi.mock('@payload-config', () => ({ default: {} }))
+
+vi.mock('@/lib/recaptcha', () => ({
+  verifyRecaptcha: verifyRecaptchaMock,
+}))
+
+import { submitContactForm } from './contact'
+import type { ContactFormState } from '@/components/ContactForm'
+
+const initialState: ContactFormState = { success: false, message: '' }
+
+const validFormData = (overrides: Record<string, string> = {}) => {
+  const fd = new FormData()
+  fd.set('fullName', 'Jane Doe')
+  fd.set('email', 'jane@example.com')
+  fd.set('comments', 'Hello, I have a question about IFRS adoption.')
+  fd.set('title', 'Director')
+  fd.set('organization', 'Acme Corp')
+  fd.set('businessPhone', '555-0100')
+  fd.set('recaptchaToken', 'token-abc')
+  for (const [k, v] of Object.entries(overrides)) fd.set(k, v)
+  return fd
+}
+
+describe('submitContactForm', () => {
+  beforeEach(() => {
+    createMock.mockReset()
+    verifyRecaptchaMock.mockReset()
+    verifyRecaptchaMock.mockResolvedValue({ success: true, score: 0.9 })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('persists a valid submission and returns success', async () => {
+    createMock.mockResolvedValue({ id: 1 })
+
+    const result = await submitContactForm(initialState, validFormData())
+
+    expect(result.success).toBe(true)
+    expect(result.message).toMatch(/thank you/i)
+    expect(createMock).toHaveBeenCalledTimes(1)
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'form-submissions',
+        overrideAccess: true,
+        data: expect.objectContaining({
+          fullName: 'Jane Doe',
+          email: 'jane@example.com',
+          comments: 'Hello, I have a question about IFRS adoption.',
+          status: 'new',
+        }),
+      }),
+    )
+  })
+
+  it('rejects missing required fields without persisting', async () => {
+    const fd = validFormData({ fullName: '', email: '', comments: '' })
+
+    const result = await submitContactForm(initialState, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.errors).toMatchObject({
+      fullName: expect.any(String),
+      email: expect.any(String),
+      comments: expect.any(String),
+    })
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid email format without persisting', async () => {
+    const fd = validFormData({ email: 'not-an-email' })
+
+    const result = await submitContactForm(initialState, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.email).toMatch(/valid email/i)
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects when reCAPTCHA verification fails', async () => {
+    verifyRecaptchaMock.mockResolvedValue({ success: false })
+
+    const result = await submitContactForm(initialState, validFormData())
+
+    expect(result.success).toBe(false)
+    expect(result.message).toMatch(/recaptcha/i)
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('returns failure (does NOT show success) when persistence throws', async () => {
+    createMock.mockRejectedValue(new Error('db down'))
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const result = await submitContactForm(initialState, validFormData())
+
+    expect(result.success).toBe(false)
+    expect(result.message).toMatch(/something went wrong/i)
+    expect(errSpy).toHaveBeenCalled()
+  })
+
+  it('honeypot trips silent-success without persisting', async () => {
+    const fd = validFormData()
+    fd.set('website', 'http://spam.example.com')
+
+    const result = await submitContactForm(initialState, fd)
+
+    expect(result.success).toBe(true)
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/actions/contact.ts
+++ b/src/actions/contact.ts
@@ -74,7 +74,7 @@ export async function submitContactForm(
     }
   }
 
-  // Store submission in Payload CMS
+  // Store submission in Payload CMS — public form, so we explicitly bypass collection access control
   try {
     const payload = await getPayload({ config })
     await payload.create({
@@ -89,6 +89,7 @@ export async function submitContactForm(
         status: 'new',
         submittedAt: new Date().toISOString(),
       },
+      overrideAccess: true,
     })
 
     return {

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -22,7 +22,7 @@
  */
 'use client'
 
-import React, { useActionState, useRef, useEffect } from 'react'
+import React, { useActionState, useRef, useEffect, useTransition } from 'react'
 import { Input } from '@/components/ui/Input'
 import { Button } from '@/components/ui/Button'
 
@@ -63,7 +63,9 @@ function validateField(name: string, value: string): string {
 }
 
 export function ContactForm({ action, getRecaptchaToken, ...props }: ContactFormProps) {
-  const [state, formAction, isPending] = useActionState(action, initialState)
+  const [state, formAction, isActionPending] = useActionState(action, initialState)
+  const [isTransitionPending, startTransition] = useTransition()
+  const isPending = isActionPending || isTransitionPending
   const [clientErrors, setClientErrors] = React.useState<Record<string, string>>({})
   const formRef = useRef<HTMLFormElement>(null)
 
@@ -122,8 +124,10 @@ export function ContactForm({ action, getRecaptchaToken, ...props }: ContactForm
       }
     }
 
-    // Submit via server action
-    formAction(formData)
+    // Submit via server action — must be inside a transition per React 19 useActionState contract
+    startTransition(() => {
+      formAction(formData)
+    })
   }
 
   // Merge client and server errors (client takes priority while interacting)


### PR DESCRIPTION
## Summary

The contact form's Server Action was already wired to write to the `form-submissions` collection — the dogfood report's "stub" diagnosis was a misread (the `[FRAS] Submit for Review (stub)` log comes from `PageBuilderClient.tsx`, not the contact form). However, the page did surface real bugs:

- React 19 warning: `useActionState was called outside of a transition`. The form invoked `formAction(formData)` from inside an event handler, which violates the React 19 contract for action dispatchers.
- Implicit `overrideAccess` on `form-submissions.create`. The collection requires an authenticated user for `create`, so a public submission only worked by relying on Local API's default `overrideAccess: true`. Making it explicit removes ambiguity and survives a future default flip.

This PR:

1. Wraps `formAction(formData)` in `startTransition` and merges `isActionPending` with `isTransitionPending` so the submit button stays disabled for the full lifecycle.
2. Sets `overrideAccess: true` explicitly on the `form-submissions.create` call.
3. Adds a unit test suite for `submitContactForm` covering: successful persist, missing required fields, invalid email, reCAPTCHA failure, **database error (proves no misleading success banner)**, and honeypot trip.

Closes #97
Tracked under #101

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 125 / 125 pass (incl. 6 new contact action tests)
- [x] `npm run build` succeeds
- [ ] Manual: `/en/contact-us` — submit a real entry, verify it lands in the admin's `form-submissions` collection and no React warning fires in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)