### PR TITLE
fix(frontend): footer copyright uses BRAND.fullName

### DIFF
--- a/src/components/layout/SiteFooter.test.tsx
+++ b/src/components/layout/SiteFooter.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { SiteFooter } from './SiteFooter'
+import { BRAND } from '@/config/brand'
+
+describe('<SiteFooter>', () => {
+  it('renders the copyright with BRAND.fullName (no legacy "Financial Reporting" prefix)', () => {
+    render(<SiteFooter footer={null} />)
+    const bar = screen.getByTestId('footer-copyright')
+    expect(bar).toHaveTextContent(BRAND.fullName)
+    expect(bar).not.toHaveTextContent('Financial Reporting')
+  })
+
+  it('renders the current year in the copyright', () => {
+    render(<SiteFooter footer={null} />)
+    const year = String(new Date().getFullYear())
+    expect(screen.getByTestId('footer-copyright')).toHaveTextContent(year)
+  })
+})

--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -18,13 +18,14 @@
  * @notes
  * - Footer data comes from CMS `footer` global via props
  * - Empty state renders a minimal footer when no data exists
- * - Copyright text is UI chrome (acceptable hardcoded string)
+ * - Copyright org name is sourced from BRAND.fullName so the rebrand stays in lockstep
  * - Policy links are UI chrome (hardcoded structural links)
  */
 import React from 'react'
 import Link from 'next/link'
 import { Container } from '@/components/ui'
 import { NewsletterCTA } from '@/components/NewsletterCTA'
+import { BRAND } from '@/config/brand'
 import type { Footer } from '@/payload-types'
 
 type SiteFooterProps = {
@@ -150,7 +151,7 @@ export function SiteFooter({ footer }: SiteFooterProps) {
         <Container>
           <div className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
             <p className="text-xs text-text-muted">
-              &copy; {currentYear} Financial Reporting &amp; Assurance Standards Canada. All rights reserved.
+              &copy; {currentYear} {BRAND.fullName}. All rights reserved.
             </p>
             <div className="flex items-center gap-4">
               <Link href="/privacy" className="text-xs text-text-muted hover:text-primary hover:underline">


### PR DESCRIPTION
## Summary

Footer copyright bar was rendering the legacy "Financial Reporting & Assurance Standards Canada" string on every public page. Replaced with `BRAND.fullName` from `src/config/brand.ts`. Added a regression test that asserts the bar contains `BRAND.fullName` and does NOT contain the legacy "Financial Reporting" prefix.

Closes #98
Tracked under #101

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 127 / 127 pass (incl. 2 new SiteFooter tests)
- [x] `npm run build` succeeds
- [ ] Manual: any `/en/*` page footer reads `© <year> Reporting and Assurance Standards (RAS) Canada. All rights reserved.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)