### PR TITLE
fix(frontend): document detail slug resolver + unify seed slugs

### DIFF
--- a/src/lib/payload-helpers.documentDetail.test.ts
+++ b/src/lib/payload-helpers.documentDetail.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { findMock } = vi.hoisted(() => ({
+  findMock: vi.fn(),
+}))
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn(async () => ({ find: findMock })),
+}))
+
+vi.mock('@payload-config', () => ({ default: {} }))
+
+import { getDocumentDetailBySlug } from './payload-helpers'
+
+describe('getDocumentDetailBySlug', () => {
+  beforeEach(() => {
+    findMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns the direct match when slug is found in document-details', async () => {
+    findMock.mockResolvedValueOnce({
+      docs: [{ id: 1, slug: 'ed-crypto-assets-dfc', title: 'Crypto' }],
+    })
+
+    const doc = await getDocumentDetailBySlug('ed-crypto-assets-dfc')
+
+    expect(doc).toMatchObject({ id: 1, title: 'Crypto' })
+    expect(findMock).toHaveBeenCalledTimes(1)
+    expect(findMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'document-details',
+        where: { slug: { equals: 'ed-crypto-assets-dfc' } },
+      }),
+    )
+  })
+
+  it('falls back to ctaHref-contains lookup with stripped -dfc suffix when direct lookup misses', async () => {
+    findMock
+      .mockResolvedValueOnce({ docs: [] }) // direct miss
+      .mockResolvedValueOnce({ docs: [{ id: 7, slug: 'dd-crypto-assets', title: 'Crypto Legacy' }] })
+
+    const doc = await getDocumentDetailBySlug('ed-crypto-assets-dfc')
+
+    expect(doc).toMatchObject({ id: 7, title: 'Crypto Legacy' })
+    expect(findMock).toHaveBeenCalledTimes(2)
+    expect(findMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        collection: 'document-details',
+        where: { 'howToReply.ctaHref': { contains: 'ed-crypto-assets' } },
+      }),
+    )
+  })
+
+  it('does not strip when slug has no -dfc suffix', async () => {
+    findMock
+      .mockResolvedValueOnce({ docs: [] })
+      .mockResolvedValueOnce({ docs: [{ id: 9 }] })
+
+    await getDocumentDetailBySlug('dp-nfp-contributions')
+
+    expect(findMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: { 'howToReply.ctaHref': { contains: 'dp-nfp-contributions' } },
+      }),
+    )
+  })
+
+  it('returns null when both lookups miss', async () => {
+    findMock
+      .mockResolvedValueOnce({ docs: [] })
+      .mockResolvedValueOnce({ docs: [] })
+
+    const doc = await getDocumentDetailBySlug('nonexistent-slug')
+
+    expect(doc).toBeNull()
+  })
+
+  it('returns null on any thrown error from payload', async () => {
+    findMock.mockRejectedValueOnce(new Error('db down'))
+
+    const doc = await getDocumentDetailBySlug('ed-crypto-assets-dfc')
+
+    expect(doc).toBeNull()
+  })
+})

--- a/src/lib/payload-helpers.ts
+++ b/src/lib/payload-helpers.ts
@@ -575,17 +575,34 @@ export async function getStandardsSectionBySlug(
 
 /**
  * Fetches a document detail by slug with full depth for relationships.
+ *
+ * The `documents-for-comment` listing pages link by their own slug (e.g.
+ * `ed-crypto-assets-dfc`). A paired `document-details` record may live
+ * under that same slug (post-fix seed) OR under a legacy `dd-X` slug.
+ * When the direct lookup misses, fall back to finding the paired record
+ * via its `howToReply.ctaHref`, which embeds the dfc slug — stripped of
+ * its trailing `-dfc` so closed-document ctaHrefs (which point at the
+ * comments PDF, not /submit-comment/...) still match.
  */
 export async function getDocumentDetailBySlug(slug: string): Promise<unknown | null> {
   try {
     const payload = await getPayload({ config })
-    const result = await payload.find({
+    const direct = await payload.find({
       collection: 'document-details',
       where: { slug: { equals: slug } },
       limit: 1,
       depth: 2,
     })
-    return result.docs[0] || null
+    if (direct.docs[0]) return direct.docs[0]
+
+    const stripped = slug.replace(/-dfc$/, '')
+    const fallback = await payload.find({
+      collection: 'document-details',
+      where: { 'howToReply.ctaHref': { contains: stripped } },
+      limit: 1,
+      depth: 2,
+    })
+    return fallback.docs[0] || null
   } catch {
     return null
   }

--- a/src/seed/index.ts
+++ b/src/seed/index.ts
@@ -1422,7 +1422,7 @@ export async function seed(_payload?: unknown) {
   const documentDetailsData = [
     {
       title: 'Crypto Assets — Proposed Amendments to ASPE',
-      slug: 'dd-crypto-assets',
+      slug: 'ed-crypto-assets-dfc',
       highlights: richText('The AcSB proposes amendments to ASPE to address the accounting for crypto assets held by private enterprises.', 'Key proposals include measurement at fair value through profit or loss and enhanced disclosure requirements.'),
       bodyContent: richTextWithHeading('h2', 'Background', 'The rapid growth of crypto assets has created a need for specific accounting guidance under ASPE. Currently, private enterprises holding crypto assets must apply existing standards that were not designed for these instruments.', 'The AcSB has developed proposed amendments to address measurement, classification, and disclosure of crypto assets.', 'These proposals are based on feedback received from stakeholders and align with international developments.'),
       commentQuestions: [
@@ -1453,7 +1453,7 @@ export async function seed(_payload?: unknown) {
     },
     {
       title: 'Revenue PS 3400 — Proposed New Section',
-      slug: 'dd-ps-3400',
+      slug: 'ed-ps-3400-dfc',
       highlights: richText('PSAB proposes a new Section PS 3400, Revenue, to replace Section PS 3100, Government Transfers.', 'The proposed standard introduces a performance obligation approach to revenue recognition in the public sector.'),
       bodyContent: richTextWithHeading('h2', 'Overview', 'The proposed revenue standard represents a significant change to how public sector entities recognize revenue. The performance obligation approach provides a more comprehensive framework for recognizing revenue from exchange and non-exchange transactions.', 'The proposed standard applies to all public sector entities that prepare financial statements in accordance with PSAS.', 'Key changes include distinguishing between revenue with and without performance obligations, measurement of revenue at transaction price, and timing of revenue recognition.'),
       commentQuestions: [
@@ -1482,7 +1482,7 @@ export async function seed(_payload?: unknown) {
     },
     {
       title: 'CSDS 1 — Re-exposure: General Requirements',
-      slug: 'dd-csds-1',
+      slug: 'red-csds-1-dfc',
       highlights: richText('The CSSB re-exposes proposed CSDS 1 incorporating feedback from the initial exposure draft.', 'Key changes include clarified transition provisions and modified proportionality mechanisms.'),
       bodyContent: richTextWithHeading('h2', 'What Changed', 'Based on feedback received during the initial comment period, the CSSB has made several changes to the proposed standard. The re-exposure draft incorporates clarified transition provisions, modified proportionality mechanisms for smaller entities, and enhanced guidance on materiality.', 'The CSSB received over 100 comment letters on the original exposure draft, representing a broad cross-section of Canadian stakeholders.'),
       commentQuestions: [
@@ -1512,7 +1512,7 @@ export async function seed(_payload?: unknown) {
     },
     {
       title: 'CSSA 5000 — Sustainability Assurance',
-      slug: 'dd-cssa-5000',
+      slug: 'ed-cssa-5000-dfc',
       highlights: richText('The AASB proposes a Canadian Standard on Sustainability Assurance aligned with ISSA 5000.', 'The proposed standard establishes requirements for assurance engagements on sustainability information.'),
       bodyContent: richTextWithHeading('h2', 'Purpose', 'As Canadian sustainability disclosure requirements evolve, there is a need for assurance standards to provide confidence in the quality and reliability of sustainability information. The proposed CSSA 5000 addresses this need.', 'The proposed standard is based on the IAASB\'s International Standard on Sustainability Assurance (ISSA) 5000, with Canadian-specific modifications.'),
       commentQuestions: [
@@ -1543,7 +1543,7 @@ export async function seed(_payload?: unknown) {
     },
     {
       title: 'NFP Contributions Revenue — Discussion Paper',
-      slug: 'dd-nfp-contributions',
+      slug: 'dp-nfp-contributions',
       highlights: richText('The AcSB invites input on the accounting for contributions revenue by not-for-profit organizations.', 'The discussion paper explores alternative approaches to recognizing contributions with conditions or restrictions.'),
       bodyContent: richTextWithHeading('h2', 'Background', 'Not-for-profit organizations often receive contributions with various conditions or restrictions. The current guidance on recognizing these contributions has been the subject of ongoing questions from stakeholders.', 'This discussion paper explores the issues and presents possible approaches for the AcSB to consider in developing improved guidance.'),
       commentQuestions: [
@@ -1571,7 +1571,7 @@ export async function seed(_payload?: unknown) {
     },
     {
       title: 'Employee Benefits PS 3250 (Closed)',
-      slug: 'dd-ps-3250',
+      slug: 'ed-ps-3250-dfc',
       highlights: richText('PSAB sought input on proposed amendments to PS 3250 Employee Benefits.', 'The comment period for this document has closed.'),
       bodyContent: richTextWithHeading('h2', 'Summary', 'The proposed amendments to PS 3250 address the accounting for employee benefits in the public sector, including pensions, other retirement benefits, and compensated absences.', 'The comment period has closed and the feedback is being analyzed by the Board.'),
       commentQuestions: [


### PR DESCRIPTION
## Summary

Document detail listings (e.g. `/en/acsb/documents`) were linking by `documents-for-comment` slug (`ed-crypto-assets-dfc`), but the detail route looked up `document-details`, whose seed used a parallel `dd-X` slug pattern. Result: every listed document 404'd.

There is no relationship field linking the two collections (and adding one is out of scope for this fix-only campaign), but `document-details.howToReply.ctaHref` consistently embeds the partner dfc slug — that gives a stable backref for legacy data.

Two-part fix:

1. **Resolver fallback** in `getDocumentDetailBySlug`: try the direct slug lookup first; on miss, fall back to finding the paired `document-details` whose `howToReply.ctaHref` contains the slug stripped of any trailing `-dfc`. This recovers detail pages on already-seeded dev DBs **without requiring re-seed**.
2. **Seed slug unification**: rename the 6 `document-details` seed slugs to match their paired `documents-for-comment` slugs (`dd-crypto-assets` → `ed-crypto-assets-dfc`, etc.). After re-seed the direct lookup hits and the fallback becomes a defensive no-op.

The 6 paired documents now resolve. The other 6 listed `documents-for-comment` rows still 404 — they don't have detail pages in the seed at all, which is a separate content gap (not in scope for #94).

Closes #94
Tracked under #101

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 132 / 132 pass (incl. 5 new resolver tests covering direct hit, fallback hit, no-strip path, double miss, thrown error)
- [x] `npm run build` succeeds
- [ ] Manual on legacy seeded DB: `/en/acsb/documents` → click "Crypto Assets" → detail page renders (uses ctaHref fallback)
- [ ] Manual after re-seed: same flow → detail page renders via direct slug match (faster, no fallback query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)