### PR TITLE
fix(frontend): RSS link generator — locale prefix + real target routes

### DIFF
--- a/src/app/api/rss/[board]/route.ts
+++ b/src/app/api/rss/[board]/route.ts
@@ -6,132 +6,54 @@
  * - Board-specific feed items
  * - Same format as main /api/rss feed
  * - Content-Type: application/rss+xml
+ * - Locale-aware: ?lang=fr serves the French feed; defaults to 'en'
  *
  * @dependencies
  * - Payload CMS local API
  *
  * @notes
  * - Route: /api/rss/[board] (e.g., /api/rss/acsb)
+ * - Channel <link> points at the board landing page (/<locale>/<boardSlug>),
+ *   not /boards/<slug> (which is a different placeholder).
  */
 import { getPayload } from 'payload'
 import config from '@payload-config'
+import {
+  buildFeedItemsForLocale,
+  buildRssXml,
+  type FeedLocale,
+} from '../feed-builder'
 
 // Force dynamic rendering — same reasoning as /api/rss; do not prerender.
 export const dynamic = 'force-dynamic'
 export const revalidate = 300
 
-function escapeXml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;')
-}
-
-type FeedItem = {
-  title: string
-  link: string
-  description: string
-  pubDate: string
-  category: string
-}
-
-async function getBoardFeedItems(boardSlug: string): Promise<FeedItem[]> {
-  const payload = await getPayload({ config })
-  const baseUrl = process.env.NEXT_PUBLIC_SERVER_URL || 'https://frascanada.ca'
-  const items: FeedItem[] = []
-
-  // Fetch news for board
-  try {
-    const news = await payload.find({
-      collection: 'news',
-      limit: 20,
-      sort: '-publishedDate',
-      where: { 'board.slug': { equals: boardSlug } },
-      depth: 1,
-    })
-    for (const item of news.docs) {
-      const doc = item as unknown as Record<string, unknown>
-      items.push({
-        title: (doc.title as string) || '',
-        link: `${baseUrl}/news/${doc.slug}`,
-        description: (doc.summary as string) || '',
-        pubDate: new Date((doc.publishedDate as string) || Date.now()).toUTCString(),
-        category: 'News',
-      })
-    }
-  } catch { /* collection may not exist yet */ }
-
-  // Fetch events for board
-  try {
-    const events = await payload.find({
-      collection: 'events',
-      limit: 20,
-      sort: '-date',
-      where: { 'board.slug': { equals: boardSlug } },
-      depth: 1,
-    })
-    for (const item of events.docs) {
-      const doc = item as unknown as Record<string, unknown>
-      items.push({
-        title: (doc.title as string) || '',
-        link: `${baseUrl}/meetings-and-events/${doc.slug}`,
-        description: (doc.summary as string) || '',
-        pubDate: new Date((doc.date as string) || Date.now()).toUTCString(),
-        category: 'Events',
-      })
-    }
-  } catch { /* collection may not exist yet */ }
-
-  items.sort((a, b) => new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime())
-  return items
-}
-
-function buildRssXml(items: FeedItem[], title: string, description: string, link: string, selfUrl: string): string {
-  const itemsXml = items
-    .map(
-      (item) => `    <item>
-      <title>${escapeXml(item.title)}</title>
-      <link>${escapeXml(item.link)}</link>
-      <description>${escapeXml(item.description)}</description>
-      <pubDate>${item.pubDate}</pubDate>
-      <category>${escapeXml(item.category)}</category>
-    </item>`,
-    )
-    .join('\n')
-
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <title>${escapeXml(title)}</title>
-    <description>${escapeXml(description)}</description>
-    <link>${escapeXml(link)}</link>
-    <language>en-CA</language>
-    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
-    <atom:link href="${escapeXml(selfUrl)}" rel="self" type="application/rss+xml" />
-${itemsXml}
-  </channel>
-</rss>`
+function resolveLocale(value: string | null): FeedLocale {
+  return value === 'fr' ? 'fr' : 'en'
 }
 
 type RouteParams = {
   params: Promise<{ board: string }>
 }
 
-export async function GET(_request: Request, { params }: RouteParams) {
+export async function GET(request: Request, { params }: RouteParams) {
   const { board: boardSlug } = await params
+  const url = new URL(request.url)
+  const locale = resolveLocale(url.searchParams.get('lang'))
   const baseUrl = process.env.NEXT_PUBLIC_SERVER_URL || 'https://frascanada.ca'
-  const items = await getBoardFeedItems(boardSlug)
-  const boardName = boardSlug.toUpperCase()
 
-  const xml = buildRssXml(
+  const payload = await getPayload({ config })
+  const items = await buildFeedItemsForLocale(payload, baseUrl, locale, boardSlug)
+
+  const boardName = boardSlug.toUpperCase()
+  const xml = buildRssXml({
     items,
-    `RAS Canada — ${boardName} Updates`,
-    `News and events from ${boardName}`,
-    `${baseUrl}/boards/${boardSlug}`,
-    `${baseUrl}/api/rss/${boardSlug}`,
-  )
+    title: `RAS Canada — ${boardName} Updates`,
+    description: `News and events from ${boardName}`,
+    link: `${baseUrl}/${locale}/${boardSlug}`,
+    selfLink: `${baseUrl}/api/rss/${boardSlug}${locale === 'fr' ? '?lang=fr' : ''}`,
+    language: locale === 'fr' ? 'fr-CA' : 'en-CA',
+  })
 
   return new Response(xml, {
     headers: {

--- a/src/app/api/rss/feed-builder.test.ts
+++ b/src/app/api/rss/feed-builder.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildDocumentForCommentLink,
+  buildEventLink,
+  buildNewsLink,
+  buildRssXml,
+  escapeXml,
+} from './feed-builder'
+
+const BASE = 'https://frascanada.ca'
+
+describe('RSS link generators', () => {
+  it('news link is /<locale>/news/<slug>', () => {
+    expect(buildNewsLink(BASE, 'en', 'crypto-explainer')).toBe(
+      'https://frascanada.ca/en/news/crypto-explainer',
+    )
+    expect(buildNewsLink(BASE, 'fr', 'crypto-explainer')).toBe(
+      'https://frascanada.ca/fr/news/crypto-explainer',
+    )
+  })
+
+  it('event link points to the board listing (/<locale>/<board>/meetings-and-events) until detail route lands', () => {
+    expect(buildEventLink(BASE, 'en', 'acsb')).toBe(
+      'https://frascanada.ca/en/acsb/meetings-and-events',
+    )
+  })
+
+  it('event link returns null when no board slug is available (caller should drop the item)', () => {
+    expect(buildEventLink(BASE, 'en', null)).toBeNull()
+  })
+
+  it('document-for-comment link uses the scope (standard or board) slug', () => {
+    expect(buildDocumentForCommentLink(BASE, 'en', 'aspe', 'ed-crypto-assets-dfc')).toBe(
+      'https://frascanada.ca/en/aspe/documents/ed-crypto-assets-dfc',
+    )
+  })
+
+  it('document-for-comment link returns null without a scope slug', () => {
+    expect(buildDocumentForCommentLink(BASE, 'en', null, 'foo')).toBeNull()
+  })
+})
+
+describe('escapeXml', () => {
+  it('escapes the five XML special characters', () => {
+    expect(escapeXml(`<a href="x">it's & "stuff"</a>`)).toBe(
+      '&lt;a href=&quot;x&quot;&gt;it&apos;s &amp; &quot;stuff&quot;&lt;/a&gt;',
+    )
+  })
+})
+
+describe('buildRssXml', () => {
+  it('renders items with all <link> URLs locale-prefixed', () => {
+    const xml = buildRssXml({
+      items: [
+        {
+          title: 'Hello',
+          link: 'https://frascanada.ca/en/news/hello',
+          description: 'desc',
+          pubDate: 'Sun, 03 May 2026 00:00:00 GMT',
+          category: 'News',
+        },
+      ],
+      title: 'Feed',
+      description: 'd',
+      link: 'https://frascanada.ca/en',
+      selfLink: 'https://frascanada.ca/api/rss',
+      language: 'en-CA',
+    })
+
+    expect(xml).toContain('<link>https://frascanada.ca/en/news/hello</link>')
+    expect(xml).toContain('<link>https://frascanada.ca/en</link>')
+    expect(xml).toContain('<language>en-CA</language>')
+    expect(xml).not.toContain('/news/hello</link>'.replace(/^\//, '<link>/'))
+  })
+
+  it('produces well-formed XML when there are no items', () => {
+    const xml = buildRssXml({
+      items: [],
+      title: 'Empty',
+      description: 'd',
+      link: 'https://frascanada.ca/en',
+      selfLink: 'https://frascanada.ca/api/rss',
+      language: 'en-CA',
+    })
+    expect(xml).toContain('<rss version="2.0"')
+    expect(xml).toContain('</channel>')
+  })
+})

--- a/src/app/api/rss/feed-builder.ts
+++ b/src/app/api/rss/feed-builder.ts
@@ -1,0 +1,220 @@
+/**
+ * @description
+ * Pure helpers for building the RSS feed: item link generators (one per
+ * collection), the Payload-backed item collector, the XML escaper, and
+ * the channel envelope renderer.
+ *
+ * Pulled out of the route handlers so the link logic is unit-testable and
+ * the global + per-board endpoints don't duplicate ~80% of code.
+ *
+ * @notes
+ * - Item links are prefixed with /<locale>/ and point at routes that
+ *   exist today. There is no /meetings-and-events/<slug> detail route,
+ *   so events link to the board's listing page (or skip if the event
+ *   has no board populated).
+ * - Documents-for-comment use the standard slug as the [board] segment
+ *   per the existing routing convention (see
+ *   `(frontend)/[locale]/(frontend)/[board]/documents/page.tsx`).
+ */
+import type { Payload, Where } from 'payload'
+
+export type FeedLocale = 'en' | 'fr'
+
+export type FeedItem = {
+  title: string
+  link: string
+  description: string
+  pubDate: string
+  category: string
+}
+
+type RelationLike = { slug?: string | null } | number | null | undefined
+
+function getRelationSlug(value: RelationLike): string | null {
+  if (!value || typeof value === 'number') return null
+  return typeof value.slug === 'string' && value.slug.length > 0 ? value.slug : null
+}
+
+/** /{locale}/news/{slug} — route exists at (frontend)/[locale]/news/[slug]. */
+export function buildNewsLink(baseUrl: string, locale: FeedLocale, slug: string): string {
+  return `${baseUrl}/${locale}/news/${slug}`
+}
+
+/**
+ * /{locale}/{boardSlug}/meetings-and-events — listing page. There is no
+ * meeting/event detail route yet, so we link to the board's listing.
+ * Returns null when no board is populated; the caller should drop the
+ * item rather than emit a broken link.
+ */
+export function buildEventLink(
+  baseUrl: string,
+  locale: FeedLocale,
+  boardSlug: string | null,
+): string | null {
+  if (!boardSlug) return null
+  return `${baseUrl}/${locale}/${boardSlug}/meetings-and-events`
+}
+
+/**
+ * /{locale}/{standardOrBoardSlug}/documents/{docSlug} — detail route exists
+ * at (frontend)/[locale]/[board]/documents/[docSlug]. The first URL segment
+ * after locale is the standard slug per the listing's generateStaticParams,
+ * but it also accepts a board slug as a fallback.
+ */
+export function buildDocumentForCommentLink(
+  baseUrl: string,
+  locale: FeedLocale,
+  scopeSlug: string | null,
+  docSlug: string,
+): string | null {
+  if (!scopeSlug) return null
+  return `${baseUrl}/${locale}/${scopeSlug}/documents/${docSlug}`
+}
+
+export function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+type FeedDoc = Record<string, unknown>
+
+export async function buildFeedItemsForLocale(
+  payload: Payload,
+  baseUrl: string,
+  locale: FeedLocale,
+  boardSlug?: string,
+): Promise<FeedItem[]> {
+  const items: FeedItem[] = []
+  const boardFilter: Where | undefined = boardSlug
+    ? { 'board.slug': { equals: boardSlug } }
+    : undefined
+
+  // News
+  try {
+    const news = await payload.find({
+      collection: 'news',
+      limit: 20,
+      sort: '-date',
+      where: boardFilter || {},
+      depth: 1,
+      locale,
+    })
+    for (const item of news.docs as unknown as FeedDoc[]) {
+      const slug = item.slug as string | undefined
+      if (!slug) continue
+      const pub = (item.publishedDate as string) || (item.date as string) || new Date().toISOString()
+      items.push({
+        title: (item.title as string) || '',
+        link: buildNewsLink(baseUrl, locale, slug),
+        description: (item.excerpt as string) || '',
+        pubDate: new Date(pub).toUTCString(),
+        category: 'News',
+      })
+    }
+  } catch {
+    /* collection may not exist yet */
+  }
+
+  // Events — listing-only link until detail route lands
+  try {
+    const events = await payload.find({
+      collection: 'events',
+      limit: 20,
+      sort: '-date',
+      where: boardFilter || {},
+      depth: 1,
+      locale,
+    })
+    for (const item of events.docs as unknown as FeedDoc[]) {
+      const slug = item.slug as string | undefined
+      if (!slug) continue
+      const itemBoardSlug = getRelationSlug(item.board as RelationLike) || boardSlug || null
+      const link = buildEventLink(baseUrl, locale, itemBoardSlug)
+      if (!link) continue
+      const pub = (item.date as string) || new Date().toISOString()
+      items.push({
+        title: (item.title as string) || '',
+        link,
+        description: (item.excerpt as string) || '',
+        pubDate: new Date(pub).toUTCString(),
+        category: 'Events',
+      })
+    }
+  } catch {
+    /* collection may not exist yet */
+  }
+
+  // Documents for comment (skipped on per-board feed since the detail
+  // route is keyed by standard slug, not board slug)
+  if (!boardSlug) {
+    try {
+      const docs = await payload.find({
+        collection: 'documents-for-comment',
+        limit: 20,
+        sort: '-publishedDate',
+        depth: 1,
+        locale,
+      })
+      for (const item of docs.docs as unknown as FeedDoc[]) {
+        const docSlug = item.slug as string | undefined
+        if (!docSlug) continue
+        const standardSlug =
+          getRelationSlug(item.standard as RelationLike) ||
+          getRelationSlug(item.board as RelationLike)
+        const link = buildDocumentForCommentLink(baseUrl, locale, standardSlug, docSlug)
+        if (!link) continue
+        const pub = (item.publishedDate as string) || new Date().toISOString()
+        items.push({
+          title: (item.title as string) || '',
+          link,
+          description: (item.title as string) || '',
+          pubDate: new Date(pub).toUTCString(),
+          category: 'Documents for Comment',
+        })
+      }
+    } catch {
+      /* collection may not exist yet */
+    }
+  }
+
+  items.sort((a, b) => new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime())
+  return items
+}
+
+export function buildRssXml(args: {
+  items: FeedItem[]
+  title: string
+  description: string
+  link: string
+  selfLink: string
+  language: string
+}): string {
+  const itemsXml = args.items
+    .map(
+      (item) => `    <item>
+      <title>${escapeXml(item.title)}</title>
+      <link>${escapeXml(item.link)}</link>
+      <description>${escapeXml(item.description)}</description>
+      <pubDate>${item.pubDate}</pubDate>
+      <category>${escapeXml(item.category)}</category>
+    </item>`,
+    )
+    .join('\n')
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(args.title)}</title>
+    <description>${escapeXml(args.description)}</description>
+    <link>${escapeXml(args.link)}</link>
+    <language>${escapeXml(args.language)}</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <atom:link href="${escapeXml(args.selfLink)}" rel="self" type="application/rss+xml" />
+${itemsXml}
+  </channel>
+</rss>`
+}

--- a/src/app/api/rss/route.ts
+++ b/src/app/api/rss/route.ts
@@ -7,7 +7,7 @@
  * - Valid RSS 2.0 XML output
  * - Includes news items, events, documents for comment
  * - Content-Type: application/rss+xml
- * - Bilingual metadata in feed title
+ * - Locale-aware: ?lang=fr serves the French feed; defaults to 'en'
  *
  * @dependencies
  * - Payload CMS local API
@@ -15,9 +15,17 @@
  * @notes
  * - Per-board feeds at /api/rss/[board]
  * - Cached for 5 minutes (ISR-like behavior)
+ * - All <link> URLs are prefixed with /<locale>/ and point at routes
+ *   that actually exist (no /meetings-and-events/<slug> detail page yet —
+ *   we link to the per-board listing until that route lands).
  */
 import { getPayload } from 'payload'
 import config from '@payload-config'
+import {
+  buildFeedItemsForLocale,
+  buildRssXml,
+  type FeedLocale,
+} from './feed-builder'
 
 // Force dynamic rendering — the feed reads from Payload at request time,
 // so it must not be prerendered at build time (which would require the
@@ -25,138 +33,29 @@ import config from '@payload-config'
 export const dynamic = 'force-dynamic'
 export const revalidate = 300 // Cache for 5 minutes at the edge.
 
-function escapeXml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;')
+function resolveLocale(value: string | null): FeedLocale {
+  return value === 'fr' ? 'fr' : 'en'
 }
 
-type FeedItem = {
-  title: string
-  link: string
-  description: string
-  pubDate: string
-  category: string
-}
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const locale = resolveLocale(url.searchParams.get('lang'))
+  const baseUrl = process.env.NEXT_PUBLIC_SERVER_URL || 'https://frascanada.ca'
 
-async function getFeedItems(boardSlug?: string): Promise<FeedItem[]> {
   const payload = await getPayload({ config })
-  const baseUrl = process.env.NEXT_PUBLIC_SERVER_URL || 'https://frascanada.ca'
-  const items: FeedItem[] = []
+  const items = await buildFeedItemsForLocale(payload, baseUrl, locale)
 
-  // Build board filter
-  const boardFilter = boardSlug
-    ? { 'board.slug': { equals: boardSlug } }
-    : undefined
-
-  // Fetch news
-  try {
-    const news = await payload.find({
-      collection: 'news',
-      limit: 20,
-      sort: '-publishedDate',
-      where: boardFilter || {},
-      depth: 1,
-    })
-    for (const item of news.docs) {
-      const doc = item as unknown as Record<string, unknown>
-      items.push({
-        title: (doc.title as string) || '',
-        link: `${baseUrl}/news/${doc.slug}`,
-        description: (doc.summary as string) || '',
-        pubDate: new Date((doc.publishedDate as string) || Date.now()).toUTCString(),
-        category: 'News',
-      })
-    }
-  } catch { /* collection may not exist yet */ }
-
-  // Fetch events
-  try {
-    const events = await payload.find({
-      collection: 'events',
-      limit: 20,
-      sort: '-date',
-      where: boardFilter || {},
-      depth: 1,
-    })
-    for (const item of events.docs) {
-      const doc = item as unknown as Record<string, unknown>
-      items.push({
-        title: (doc.title as string) || '',
-        link: `${baseUrl}/meetings-and-events/${doc.slug}`,
-        description: (doc.summary as string) || '',
-        pubDate: new Date((doc.date as string) || Date.now()).toUTCString(),
-        category: 'Events',
-      })
-    }
-  } catch { /* collection may not exist yet */ }
-
-  // Fetch documents for comment
-  try {
-    const docs = await payload.find({
-      collection: 'documents-for-comment',
-      limit: 20,
-      sort: '-publishedDate',
-      where: boardFilter || {},
-      depth: 1,
-    })
-    for (const item of docs.docs) {
-      const doc = item as unknown as Record<string, unknown>
-      items.push({
-        title: (doc.title as string) || '',
-        link: `${baseUrl}/open-for-comment/${doc.slug}`,
-        description: (doc.summary as string) || '',
-        pubDate: new Date((doc.publishedDate as string) || Date.now()).toUTCString(),
-        category: 'Documents for Comment',
-      })
-    }
-  } catch { /* collection may not exist yet */ }
-
-  // Sort by date descending
-  items.sort((a, b) => new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime())
-
-  return items
-}
-
-function buildRssXml(items: FeedItem[], title: string, description: string, link: string): string {
-  const itemsXml = items
-    .map(
-      (item) => `    <item>
-      <title>${escapeXml(item.title)}</title>
-      <link>${escapeXml(item.link)}</link>
-      <description>${escapeXml(item.description)}</description>
-      <pubDate>${item.pubDate}</pubDate>
-      <category>${escapeXml(item.category)}</category>
-    </item>`,
-    )
-    .join('\n')
-
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <title>${escapeXml(title)}</title>
-    <description>${escapeXml(description)}</description>
-    <link>${escapeXml(link)}</link>
-    <language>en-CA</language>
-    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
-    <atom:link href="${escapeXml(link)}/api/rss" rel="self" type="application/rss+xml" />
-${itemsXml}
-  </channel>
-</rss>`
-}
-
-export async function GET() {
-  const baseUrl = process.env.NEXT_PUBLIC_SERVER_URL || 'https://frascanada.ca'
-  const items = await getFeedItems()
-  const xml = buildRssXml(
+  const xml = buildRssXml({
     items,
-    'RAS Canada — Latest Updates',
-    'News, events, and documents for comment from RAS Canada',
-    baseUrl,
-  )
+    title: locale === 'fr' ? 'NIFC Canada — Dernières mises à jour' : 'RAS Canada — Latest Updates',
+    description:
+      locale === 'fr'
+        ? 'Nouvelles, événements et documents pour commentaires de NIFC Canada'
+        : 'News, events, and documents for comment from RAS Canada',
+    link: `${baseUrl}/${locale}`,
+    selfLink: `${baseUrl}/api/rss${locale === 'fr' ? '?lang=fr' : ''}`,
+    language: locale === 'fr' ? 'fr-CA' : 'en-CA',
+  })
 
   return new Response(xml, {
     headers: {


### PR DESCRIPTION
## Summary

Both RSS endpoints emitted `<link>` URLs that all 404'd in the wild: missing locale segment, wrong field names (`summary` instead of `excerpt`), and target routes that don't exist (`/meetings-and-events/<slug>`, `/open-for-comment/<slug>`, `/boards/<slug>`).

This PR extracts the link generators into a tested `feed-builder` module and rebuilds the routes around it:

- **News:** `/<locale>/news/<slug>` (route exists, shipped in PR #105)
- **Events:** `/<locale>/<boardSlug>/meetings-and-events` — the board's listing page, until per-event detail route lands. Items without a populated board are dropped rather than emit a broken link.
- **Documents-for-comment:** `/<locale>/<standardSlug>/documents/<slug>` (route exists, paired-slug resolver shipped in PR #106). Skipped on per-board feeds since the detail route is keyed by standard slug, not board slug.
- **Channel `<link>`:** `/<locale>` (homepage) for the global feed; `/<locale>/<boardSlug>` (board landing) for per-board feed.
- **Locale:** `?lang=fr` query param serves the French feed; defaults to `en`.

Live verification (`curl http://localhost:3000/api/rss | grep '<link>'`) shows every URL now points at a 200-OK route.

Closes #90
Tracked under #101

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 140 / 140 pass (incl. 8 new feed-builder tests covering each link generator, the XML escaper, and the channel envelope)
- [x] `npm run build` succeeds
- [x] Manual: `curl /api/rss` and `curl /api/rss/acsb` — every `<link>` returns `200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)