### PR TITLE
docs(dx): document Portless local-URL setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ DATABASE_URI=postgresql://postgres:postgres@localhost:5432/fras
 PAYLOAD_SECRET=CHANGE_ME_GENERATE_WITH_openssl_rand_hex_32
 
 # Base URL for the application (used by Payload for links, CORS)
+# - Plain dev: http://localhost:3000
+# - Portless dev (recommended — see README "Local URLs"): https://fras.test
 NEXT_PUBLIC_SERVER_URL=http://localhost:3000
 
 # Secret used by /api/preview to authenticate live-preview iframe requests

--- a/README.md
+++ b/README.md
@@ -33,6 +33,34 @@ docker compose up -d
 npm run dev
 ```
 
+## Local URLs (recommended Portless setup)
+
+Three services run on `localhost` ports during dev:
+
+| Service       | Default port | Suggested Portless alias |
+|---------------|--------------|--------------------------|
+| Next dev      | `:3000`      | `https://fras.test`      |
+| PostgreSQL    | `:5433`      | (keep direct — native protocol) |
+| Meilisearch   | `:7700`      | `https://meili.fras.test` (optional) |
+
+[Portless](https://portless.dev/) is a Mac app that gives you memorable HTTPS subdomains for local services without editing `/etc/hosts`. Once installed:
+
+1. Open Portless and create an app:
+   - **Name:** `fras`
+   - **Subdomain:** `fras.test` (or `fras.lcl.host` on the public TLD)
+   - **Port:** `3000`
+2. Optionally add a second app for Meilisearch (`meili.fras.test` → `:7700`).
+3. Update `.env` so Next emits the matching `NEXT_PUBLIC_SERVER_URL`:
+   ```
+   NEXT_PUBLIC_SERVER_URL=https://fras.test
+   # NEXT_PUBLIC_MEILISEARCH_HOST=https://meili.fras.test  (only if you proxied Meili too)
+   ```
+4. Restart `npm run dev`. The browser bar now reads `https://fras.test/en` instead of `localhost:3000`.
+
+PostgreSQL stays as `localhost:5433` because the wire protocol isn't HTTP — Portless can't proxy it.
+
+**Not on Mac?** Use [Caddy](https://caddyserver.com/) with a similar reverse-proxy config — same idea, different toolchain.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary

Three services run on `localhost` during dev (Next :3000, Postgres :5433, Meilisearch :7700) — easy to lose track of which window is which. Add a "Local URLs" section to README recommending [Portless](https://portless.dev/) aliases (`fras.test` → `:3000`, optional `meili.fras.test` → `:7700`) and the matching `NEXT_PUBLIC_SERVER_URL` change. Inline the option in `.env.example` so anyone copying the example sees it.

PostgreSQL stays direct (`localhost:5433`) — native protocol, not HTTP, so Portless can't proxy it.

Doc-only. No code changes.

## Test plan

- [x] `git diff` reviewed
- [ ] Manual: install Portless, alias `fras.test` → `:3000`, set `NEXT_PUBLIC_SERVER_URL=https://fras.test` in `.env`, restart `npm run dev`, browse to `https://fras.test/en` (deferred to consumer of the PR — pure docs change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)