### PR TITLE
fix(frontend): mega-menu panel no longer overflows viewport on the right

### DIFF
--- a/src/components/layout/MegaMenu.test.tsx
+++ b/src/components/layout/MegaMenu.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { MegaMenu } from './MegaMenu'
+
+const items = [
+  {
+    label: 'Boards',
+    href: '/boards',
+    children: [
+      { label: 'AcSB', href: '/acsb' },
+      { label: 'PSAB', href: '/psab' },
+      { label: 'AASB', href: '/aasb' },
+      { label: 'CSSB', href: '/cssb' },
+    ],
+  },
+  { label: 'Standards', href: '/standards' },
+  { label: 'News', href: '/news' },
+  { label: 'Resources', href: '/resources' },
+]
+
+function openPanel(triggerLabel = 'Boards') {
+  const trigger = screen.getByTestId(`mega-menu-trigger-${triggerLabel.toLowerCase()}`)
+  fireEvent.click(trigger)
+}
+
+describe('<MegaMenu>', () => {
+  it('clamps the multi-column panel to viewport width (no overflow class)', () => {
+    render(<MegaMenu trigger="Boards" items={items} variant="multi-column" />)
+    openPanel()
+
+    const panel = screen.getByTestId('mega-menu-panel-boards')
+    // Width is clamped via min(680px, 100vw - 2rem) so the panel can never
+    // grow large enough to push body horizontal scroll.
+    expect(panel.className).toContain('w-[min(680px,calc(100vw-2rem))]')
+    // The legacy bug was `w-max` which lets the panel grow with content.
+    expect(panel.className).not.toContain('w-max')
+  })
+
+  it('left-anchors by default', () => {
+    render(<MegaMenu trigger="Boards" items={items} variant="multi-column" />)
+    openPanel()
+    const panel = screen.getByTestId('mega-menu-panel-boards')
+    expect(panel.className).toContain('left-0')
+    expect(panel.className).not.toContain('right-0')
+  })
+
+  it('right-anchors when align="right" so utility-bar dropdowns grow leftward', () => {
+    render(
+      <MegaMenu trigger="Boards" items={items} variant="multi-column" align="right" />,
+    )
+    openPanel()
+    const panel = screen.getByTestId('mega-menu-panel-boards')
+    expect(panel.className).toContain('right-0')
+    expect(panel.className).toContain('left-auto')
+  })
+
+  it('single-column panel keeps a viewport-bound max-width too', () => {
+    render(<MegaMenu trigger="About" items={items} variant="single-column" />)
+    openPanel('About')
+    const panel = screen.getByTestId('mega-menu-panel-about')
+    expect(panel.className).toContain('max-w-[calc(100vw-2rem)]')
+  })
+
+  it('multi-column grid is responsive: 2 cols on small screens, 4 on sm+', () => {
+    render(<MegaMenu trigger="Boards" items={items} variant="multi-column" />)
+    openPanel()
+    const grid = screen.getByTestId('mega-menu-panel-boards').querySelector('div.grid')
+    expect(grid?.className).toContain('grid-cols-2')
+    expect(grid?.className).toContain('sm:grid-cols-4')
+  })
+})

--- a/src/components/layout/MegaMenu.tsx
+++ b/src/components/layout/MegaMenu.tsx
@@ -31,6 +31,7 @@ export type MegaMenuItem = {
 }
 
 export type MegaMenuVariant = 'single-column' | 'multi-column'
+export type MegaMenuAlign = 'left' | 'right'
 
 type MegaMenuProps = {
   /** Trigger label text */
@@ -39,10 +40,23 @@ type MegaMenuProps = {
   items: MegaMenuItem[]
   /** Layout variant */
   variant?: MegaMenuVariant
+  /**
+   * Which edge of the trigger to anchor the panel to. Use 'right' for
+   * triggers near the right edge of the viewport (e.g. utility-bar items)
+   * so the panel grows leftward and can't push body horizontal scroll.
+   * Default 'left'.
+   */
+  align?: MegaMenuAlign
   className?: string
 }
 
-export function MegaMenu({ trigger, items, variant = 'single-column', className = '' }: MegaMenuProps) {
+export function MegaMenu({
+  trigger,
+  items,
+  variant = 'single-column',
+  align = 'left',
+  className = '',
+}: MegaMenuProps) {
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const panelRef = useRef<HTMLDivElement>(null)
 
@@ -85,13 +99,21 @@ export function MegaMenu({ trigger, items, variant = 'single-column', className 
 
           <PopoverPanel
             ref={panelRef}
-            className="absolute left-0 z-50 mt-2 w-max min-w-[200px] rounded-md bg-white shadow-lg ring-1 ring-black/5"
+            className={[
+              'absolute z-50 mt-2 rounded-md bg-white shadow-lg ring-1 ring-black/5',
+              align === 'right' ? 'right-0 left-auto' : 'left-0',
+              variant === 'multi-column'
+                ? // 4 cols × ~150px + padding; clamped so it can never push body overflow.
+                  'w-[min(680px,calc(100vw-2rem))]'
+                : // narrow flyout sized to content, still clamped to viewport.
+                  'w-max min-w-[200px] max-w-[calc(100vw-2rem)]',
+            ].join(' ')}
             data-testid={`mega-menu-panel-${trigger.toLowerCase().replace(/\s+/g, '-')}`}
           >
             {variant === 'multi-column' ? (
-              <div className="grid grid-cols-4 gap-0 p-4">
+              <div className="grid grid-cols-2 gap-0 p-4 sm:grid-cols-4">
                 {items.map((column) => (
-                  <div key={column.label} className="min-w-[180px] px-4">
+                  <div key={column.label} className="min-w-0 px-3">
                     <Link
                       href={column.href}
                       className="block text-sm font-bold text-primary hover:underline"

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -117,6 +117,7 @@ export function SiteHeader({ navigation, popularTags }: SiteHeaderProps) {
                       trigger={item.label}
                       items={items}
                       variant={isMultiColumn ? 'multi-column' : 'single-column'}
+                      align="right"
                     />
                   </React.Fragment>
                 )


### PR DESCRIPTION
## Summary

Reported during the mid-loop frontend QA pass: when a utility-bar mega-menu trigger (right-justified row) is opened, the multi-column panel grows past the right edge of the viewport and forces body horizontal scroll — the whole page becomes scroll-wider than the viewport.

Root cause: panel was `absolute left-0 w-max`. With \`w-max\`, a 4-column panel (4 × 180px min + padding) intrinsically wants ~720-800px; \`left-0\` anchors it to the trigger's left edge; trigger near the right edge → panel extends ~800px further right → body grows.

Two-part fix:

1. **Width clamps:** multi-column panel becomes \`w-[min(680px, calc(100vw - 2rem))]\` and single-column gets \`max-w-[calc(100vw-2rem)]\`. The panel can never widen the body regardless of trigger position.
2. **\`align\` prop:** new \`align="right" | "left"\` prop. \`SiteHeader\` passes \`align="right"\` for utility-bar triggers so the panel anchors to the trigger's right edge and grows leftward into the viewport. Primary nav keeps the default \`align="left"\`.

Also tightened the inner grid (2 cols → 4 at \`sm:\`) and shrank per-column padding so the columns breathe inside the new envelope.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npx vitest run\` — 190/190 (incl. 5 new MegaMenu tests pinning width clamps, default + right alignment, responsive grid)
- [x] \`npm run build\` succeeds
- [ ] Manual: open the utility-bar mega-menu — panel grows leftward, no body horizontal scroll. Open a primary-nav mega-menu — panel grows rightward as before, still inside viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)