### PR TITLE
fix(content): protect boards.abbreviation from translation + restore script

### DIFF
--- a/scripts/restore-board-abbreviations.mjs
+++ b/scripts/restore-board-abbreviations.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Restore the canonical English board abbreviations on the `boards` base
+ * table.
+ *
+ * Background: `boards.abbreviation` is NOT localized — it lives as a
+ * single column on the base `boards` table. The 2026-05-01 translation
+ * batch translated it to French (CNC, CCSP, CNAC, CCNID, CSNIC),
+ * overwriting the EN values that every public render relies on. This
+ * script rewrites them back to AcSB / PSAB / AASB / CSSB / RASOC by
+ * looking up each row's English slug.
+ *
+ * Idempotent: safe to run any time. The future-proof fix is in
+ * `src/lib/translation/field-picker.ts` where `abbreviation` is now in
+ * `SYSTEM_FIELDS`, so the next translation batch leaves it alone.
+ *
+ * Usage:
+ *   node scripts/restore-board-abbreviations.mjs
+ */
+
+import { getPayload } from 'payload'
+import config from '../src/payload.config.ts'
+
+const CANONICAL = {
+  acsb: 'AcSB',
+  psab: 'PSAB',
+  aasb: 'AASB',
+  cssb: 'CSSB',
+  rasoc: 'RASOC',
+}
+
+async function main() {
+  const payload = await getPayload({ config })
+  const result = await payload.find({
+    collection: 'boards',
+    locale: 'en',
+    limit: 100,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  let updated = 0
+  for (const board of result.docs) {
+    const slug = board.slug
+    const expected = CANONICAL[slug]
+    if (!expected) {
+      console.warn(`  ⚠ ${slug}: no canonical abbreviation mapping (skipping)`)
+      continue
+    }
+    if (board.abbreviation === expected) {
+      console.log(`  ✓ ${slug}: already ${expected}`)
+      continue
+    }
+    await payload.update({
+      collection: 'boards',
+      id: board.id,
+      data: { abbreviation: expected },
+      overrideAccess: true,
+    })
+    console.log(`  ✓ ${slug}: ${board.abbreviation} → ${expected}`)
+    updated += 1
+  }
+  console.log(`\nDone. ${updated} board(s) updated.`)
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/lib/translation/field-picker.ts
+++ b/src/lib/translation/field-picker.ts
@@ -23,6 +23,11 @@ export const SYSTEM_FIELDS = new Set([
   'updatedAt',
   '_status',
   'sortOrder',
+  // `boards.abbreviation` is a single non-localized column on the base
+  // table. Translating it overwrites the EN value with FR (e.g. AcSB →
+  // CNC), corrupting every render that uses the abbreviation. Keep it
+  // out of any future translation batch.
+  'abbreviation',
   'workflowState',
   'workflowHistory',
   'createdBy',


### PR DESCRIPTION
## Summary

The 2026-05-01 translation batch wrote French abbreviations (CNC, CCSP, CNAC, CCNID, CSNIC) into the \`boards.abbreviation\` column. That column is NOT localized — it's a single value on the base table — so every public render that reads \`board.abbreviation\` (board landing H1, breadcrumb, homepage promo cards, news bylines) was showing the FR code on EN pages.

This is the actual root cause of dogfood findings #81 / #92 — not a renderer bug.

Two-part fix:

1. **\`src/lib/translation/field-picker.ts\`** — add \`'abbreviation'\` to \`SYSTEM_FIELDS\` so any future translate run skips the field entirely.
2. **\`scripts/restore-board-abbreviations.mjs\`** — idempotent restore script. Walks the \`boards\` collection, looks at each row's slug, rewrites the abbreviation to the canonical EN code (acsb→AcSB, psab→PSAB, aasb→AASB, cssb→CSSB, rasoc→RASOC).

The local dev DB has already been corrected manually (\`UPDATE boards SET abbreviation = ...\`). The script is checked in for any other environment that hit the same bug — and to make the recovery reproducible.

Closes #81
Closes #92
Tracked under #101

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npx vitest run\` — 199/199 (incl. translation field-picker tests)
- [x] \`npm run build\` succeeds
- [x] Live curl: \`/en/acsb\` H1 reads "AcSB — Accounting Standards Board"; \`/en\` shows AcSB / AASB / CSSB (no CNC / CNAC / CCNID leaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)