### PR TITLE
fix(frontend): drop ssr:false on header overlays — restore SSR for every page

### DIFF
--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -32,9 +32,18 @@ import { MegaMenu } from './MegaMenu'
 import type { MegaMenuItem } from './MegaMenu'
 import type { Navigation } from '@/payload-types'
 
-/** Lazy-load interaction-triggered overlays to reduce initial bundle */
-const MobileMenu = dynamic(() => import('./MobileMenu').then((m) => ({ default: m.MobileMenu })), { ssr: false })
-const SearchModal = dynamic(() => import('@/components/SearchModal').then((m) => ({ default: m.SearchModal })), { ssr: false })
+/**
+ * Lazy-load interaction-triggered overlays to reduce initial bundle.
+ *
+ * `ssr: false` was previously set on these dynamic imports — that forced
+ * every page rendering `<SiteHeader/>` to bail out of SSR entirely
+ * ("Bail out to client-side rendering: next/dynamic"), shipping a blank
+ * shell to crawlers and breaking first-paint heading order. Both
+ * components are state-gated overlays that render `null` until opened,
+ * so letting them SSR is harmless and recovers full SSR for the page.
+ */
+const MobileMenu = dynamic(() => import('./MobileMenu').then((m) => ({ default: m.MobileMenu })))
+const SearchModal = dynamic(() => import('@/components/SearchModal').then((m) => ({ default: m.SearchModal })))
 
 type PopularTag = { label: string; query: string; id?: string }
 


### PR DESCRIPTION
## Summary

Critical from the 2026-05-03 frontend dogfood pass: every page bailed out of SSR with the marker \`BAILOUT_TO_CLIENT_SIDE_RENDERING\` (\"Bail out to client-side rendering: next/dynamic\"). Crawlers got an empty shell, raw HTML had the footer's H2 before the page H1, and first paint waited on client hydration.

Root cause was NOT Clerk (the dogfood report's \"Clerk CheckoutProvider throws\" hypothesis was wrong) — it was \`SiteHeader\` lazy-loading \`MobileMenu\` and \`SearchModal\` with \`next/dynamic({ ssr: false })\`. In Next 15 / Turbopack, an \`ssr: false\` dynamic import inside the layout tree poisons the whole surrounding page.

Both components are state-gated overlays that render \`null\` until the user opens them. Removing \`ssr: false\` keeps the JS lazy-loaded (the dynamic import still splits the chunk) but lets the rest of the page tree SSR normally.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npx vitest run\` — 199/199
- [x] \`npm run build\` succeeds
- [x] Live verify: \`curl /en | grep '<h1'\` — H1 present in initial HTML; \`grep BAILOUT\` — no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)