### PR TITLE
fix(frontend): wire stable id/name on search filter inputs

### DIFF
--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -173,33 +173,42 @@ function AccordionSection({
 
       {isOpen && (
         <div className="px-4 pb-3 space-y-2">
-          {section.options.map((option) => (
-            <label
-              key={option.value}
-              className="flex items-center gap-2 text-sm text-text-primary cursor-pointer"
-            >
-              {section.type === 'checkbox' ? (
-                <input
-                  type="checkbox"
-                  checked={activeValues.includes(option.value)}
-                  onChange={(e) => handleCheckboxChange(option.value, e.target.checked)}
-                  className="h-6 w-6 rounded border-gray-300 text-primary focus:ring-primary-bright"
-                />
-              ) : (
-                <input
-                  type="radio"
-                  name={section.id}
-                  checked={activeValues.includes(option.value)}
-                  onChange={() => handleRadioChange(option.value)}
-                  className="h-6 w-6 border-gray-300 text-primary focus:ring-primary-bright"
-                />
-              )}
-              <span className="min-w-0 break-words">{option.label}</span>
-              {option.count !== undefined && (
-                <span className="text-text-muted">({option.count})</span>
-              )}
-            </label>
-          ))}
+          {section.options.map((option) => {
+            const inputId = `filter-${section.id}-${option.value}`
+            return (
+              <label
+                key={option.value}
+                htmlFor={inputId}
+                className="flex items-center gap-2 text-sm text-text-primary cursor-pointer"
+              >
+                {section.type === 'checkbox' ? (
+                  <input
+                    id={inputId}
+                    name={`${section.id}[]`}
+                    value={option.value}
+                    type="checkbox"
+                    checked={activeValues.includes(option.value)}
+                    onChange={(e) => handleCheckboxChange(option.value, e.target.checked)}
+                    className="h-6 w-6 rounded border-gray-300 text-primary focus:ring-primary-bright"
+                  />
+                ) : (
+                  <input
+                    id={inputId}
+                    name={section.id}
+                    value={option.value}
+                    type="radio"
+                    checked={activeValues.includes(option.value)}
+                    onChange={() => handleRadioChange(option.value)}
+                    className="h-6 w-6 border-gray-300 text-primary focus:ring-primary-bright"
+                  />
+                )}
+                <span className="min-w-0 break-words">{option.label}</span>
+                {option.count !== undefined && (
+                  <span className="text-text-muted">({option.count})</span>
+                )}
+              </label>
+            )
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Search filter checkboxes / radios in `FilterSidebar` rendered with empty `id` and `name`, breaking explicit `<label htmlFor>` association and screen-reader semantics.
- Each option now gets a deterministic `filter-<sectionId>-<value>` id wired into both the input and the wrapping `<label>`, plus a `name` attribute (`<sectionId>[]` for checkboxes, `<sectionId>` for radios) and `value`.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (32 files, 204 tests pass)
- [ ] Manual: visit `/en/search?q=board`, inspect any By Board / By Standard / Content Type checkbox — `id` and `name` are populated; clicking the label toggles the box.

Closes #123
Tracked under #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)