### PR TITLE
fix(frontend): resolve homepage axe-core violations

### DIFF
--- a/src/app/(frontend)/[locale]/(frontend)/[board]/about/annual-report/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/[board]/about/annual-report/page.tsx
@@ -95,7 +95,7 @@ export default async function AnnualReportPage({ params }: PageProps) {
         </aside>
 
         {/* Main Content */}
-        <main data-testid="main-content" className="flex flex-col gap-6">
+        <div data-testid="main-content" className="flex flex-col gap-6">
           <h1 className="text-3xl font-bold text-text-primary">
             {page?.title || 'Annual Report'}
           </h1>
@@ -111,7 +111,7 @@ export default async function AnnualReportPage({ params }: PageProps) {
               Annual report content is not yet available. Please check back soon.
             </p>
           )}
-        </main>
+        </div>
       </div>
     </Container>
   )

--- a/src/app/(frontend)/[locale]/(frontend)/[board]/documents/[docSlug]/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/[board]/documents/[docSlug]/page.tsx
@@ -101,7 +101,7 @@ export default async function DocumentDetailPage({ params }: Props) {
     <div className="mx-auto max-w-[1440px] px-4 py-8 sm:px-6 lg:px-8" data-testid="page-document-detail">
       <div className="flex flex-col gap-8 lg:flex-row">
         {/* Main content (~70%) */}
-        <main className="lg:w-[70%]" data-testid="main-content">
+        <div className="lg:w-[70%]" data-testid="main-content">
           {/* Title */}
           <h1 className="text-3xl font-bold text-primary">{title}</h1>
 
@@ -175,7 +175,7 @@ export default async function DocumentDetailPage({ params }: Props) {
               <SupportMaterialsList materials={supportMaterials} />
             </section>
           )}
-        </main>
+        </div>
 
         {/* Sidebar (~30%) */}
         <aside className="lg:w-[30%]" data-testid="right-rail">

--- a/src/app/(frontend)/[locale]/(frontend)/active-projects/ActiveProjectsClient.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/active-projects/ActiveProjectsClient.tsx
@@ -105,7 +105,7 @@ export function ActiveProjectsClient({
       </aside>
 
       {/* Main content */}
-      <main data-testid="main-content">
+      <div data-testid="main-content">
         {/* Filter bar */}
         <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-center">
           <div className="relative flex-1">
@@ -178,7 +178,7 @@ export function ActiveProjectsClient({
             })}
           </div>
         )}
-      </main>
+      </div>
     </div>
   )
 }

--- a/src/app/(frontend)/[locale]/(frontend)/active-projects/[board]/[project-slug]/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/active-projects/[board]/[project-slug]/page.tsx
@@ -153,7 +153,7 @@ export default async function ProjectDetailPage({ params }: PageProps) {
         </aside>
 
         {/* Main content */}
-        <main className="space-y-10" data-testid="main-content">
+        <div className="space-y-10" data-testid="main-content">
           {/* Summary section */}
           {project.summary && (
             <section data-testid="section-summary">
@@ -220,7 +220,7 @@ export default async function ProjectDetailPage({ params }: PageProps) {
               </div>
             </section>
           )}
-        </main>
+        </div>
 
         {/* Right sidebar */}
         <aside className="space-y-8" data-testid="right-rail">

--- a/src/app/(frontend)/[locale]/(frontend)/boards/[board-slug]/BoardDetailClient.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/boards/[board-slug]/BoardDetailClient.tsx
@@ -80,7 +80,7 @@ export function BoardDetailClient({
       </aside>
 
       {/* Main content area */}
-      <main data-testid="main-content">
+      <div data-testid="main-content">
         {/* Active tab content placeholder */}
         {tabs.map((tab) => (
           <section
@@ -113,7 +113,7 @@ export function BoardDetailClient({
             <p>No content sections configured for this board.</p>
           </div>
         )}
-      </main>
+      </div>
 
       {/* Right sidebar */}
       <aside className="space-y-8" data-testid="right-rail">

--- a/src/app/(frontend)/[locale]/(frontend)/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/page.tsx
@@ -53,19 +53,19 @@ export default async function HomePage({ params }: PageProps) {
   // Empty state when homepage global is not configured
   if (!homepage) {
     return (
-      <main data-testid="page-homepage" className="min-h-screen">
+      <div data-testid="page-homepage" className="min-h-screen">
         <div className="flex items-center justify-center py-24">
           <p className="text-text-muted">Homepage content not configured.</p>
         </div>
-      </main>
+      </div>
     )
   }
 
   return (
-    <main data-testid="page-homepage" className="min-h-screen">
+    <div data-testid="page-homepage" className="min-h-screen">
       <OrganizationSchema />
       <RenderHero {...homepage.hero} />
       <RenderBlocks blocks={homepage.layout} />
-    </main>
+    </div>
   )
 }

--- a/src/blocks/BrowseByStandardBlock/Component.tsx
+++ b/src/blocks/BrowseByStandardBlock/Component.tsx
@@ -43,15 +43,23 @@ type BrowseByStandardBlockProps = {
 
 function CategoryCard({ category }: { category: Category }) {
   const [isExpanded, setIsExpanded] = useState(false)
+  const populatedLinks = (category.links || []).filter((l) => l.label && l.url)
+
+  // Don't render an empty card — the surrounding component already filters
+  // these out, but guard anyway so a partially-populated CMS row can't emit
+  // empty <h3> / <a> nodes that fail axe-core's empty-heading rule.
+  if (!category.name && populatedLinks.length === 0) return null
 
   return (
     <div className="rounded-md border border-gray-200 bg-white">
       {/* Desktop: always visible */}
       <div className="hidden md:block p-6">
-        <h3 className="mb-4 text-lg font-bold text-primary">{category.name}</h3>
-        {category.links && category.links.length > 0 && (
+        {category.name && (
+          <h3 className="mb-4 text-lg font-bold text-primary">{category.name}</h3>
+        )}
+        {populatedLinks.length > 0 && (
           <ul className="space-y-2">
-            {category.links.map((link, i) => (
+            {populatedLinks.map((link, i) => (
               <li key={link.id || i}>
                 <a
                   href={link.url}
@@ -73,7 +81,11 @@ function CategoryCard({ category }: { category: Category }) {
           className="flex w-full items-center justify-between p-4 text-left"
           aria-expanded={isExpanded}
         >
-          <h3 className="text-lg font-bold text-primary">{category.name}</h3>
+          {category.name ? (
+            <h3 className="text-lg font-bold text-primary">{category.name}</h3>
+          ) : (
+            <span className="text-lg font-bold text-primary">Standards</span>
+          )}
           <span
             className={`text-text-muted transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
             aria-hidden="true"
@@ -81,9 +93,9 @@ function CategoryCard({ category }: { category: Category }) {
             &#9660;
           </span>
         </button>
-        {isExpanded && category.links && category.links.length > 0 && (
+        {isExpanded && populatedLinks.length > 0 && (
           <ul className="space-y-2 px-4 pb-4">
-            {category.links.map((link, i) => (
+            {populatedLinks.map((link, i) => (
               <li key={link.id || i}>
                 <a
                   href={link.url}

--- a/src/components/NewsletterCTA.tsx
+++ b/src/components/NewsletterCTA.tsx
@@ -70,7 +70,9 @@ export function NewsletterCTA({
 
   return (
     <div className={`${className}`.trim()} data-testid="newsletter-cta">
-      <h2 className="text-2xl font-bold text-text-primary">{heading}</h2>
+      {heading && (
+        <h2 className="text-2xl font-bold text-text-primary">{heading}</h2>
+      )}
 
       {description && <p className="mt-2 text-base text-text-muted">{description}</p>}
 

--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -138,8 +138,8 @@ export function SiteFooter({ footer }: SiteFooterProps) {
           <Container>
             <div className="py-8">
               <NewsletterCTA
-                heading={newsletterHeading || ''}
-                description={newsletterDescription || ''}
+                heading={newsletterHeading || undefined}
+                description={newsletterDescription || undefined}
               />
             </div>
           </Container>


### PR DESCRIPTION
## Summary
- Multiple page-level components were rendering their own \`<main>\` element inside the locale layout's \`<main>\`, producing duplicate / nested-not-top-level / non-unique landmark violations and dropping the page body out of any region. Switched the page-level wrappers to plain \`<div data-testid="main-content">\` so the layout owns the single \`<main>\` landmark.
- The Browse by Standard block was emitting empty \`<h3>\` and \`<a>\` elements whenever a CMS row's localized fields were absent. Each card now skips rendering when its data is missing and filters out unpopulated links; the desktop and mobile heading variants both early-return.
- \`NewsletterCTA\` rendered an empty \`<h2>\` whenever \`heading=""\` was passed; guarded the heading and switched the footer to pass \`undefined\` so the default copy fills in.

## Test plan
- [x] \`npx tsc --noEmit\`
- [x] \`npx vitest run\` (32 files / 204 tests pass)
- [x] Live HTML check on \`/en\`: only one \`<main>\` element, no empty heading nodes, hero \`<h1>\` is the only h1 in the document body.

Closes #99
Tracked under #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)