### PR TITLE
fix(frontend): add bg-badge-survey token for Survey project badges

### DIFF
--- a/src/app/(frontend)/[locale]/(frontend)/globals.css
+++ b/src/app/(frontend)/[locale]/(frontend)/globals.css
@@ -81,6 +81,10 @@
   --color-badge-decision: #243E90;
   --color-badge-deadline: #9F2528;
   --color-badge-resource: #8E3387;
+  /* Survey is conceptually closer to research/feedback than to a webinar.
+     Picked a deeper amber so it reads as distinct from resource (purple)
+     and webinar (teal) at card-row scan distance. */
+  --color-badge-survey: #B45309;
 
   /* ── Board-Specific Colors ── */
   --color-board-fras: #601F5B;

--- a/src/components/ContentTypeBadge.tsx
+++ b/src/components/ContentTypeBadge.tsx
@@ -53,7 +53,7 @@ const typeToVariant: Record<ContentType, React.ComponentProps<typeof Badge>['var
   'meeting-summary': 'meeting',
   guidance: 'guidance',
   'exposure-draft': 'consultation',
-  survey: 'resource',
+  survey: 'survey',
   're-exposure-draft': 'deadline',
   research: 'decision',
   'public-comment': 'standard',

--- a/src/components/board/ConsultationCard.tsx
+++ b/src/components/board/ConsultationCard.tsx
@@ -61,10 +61,10 @@ function formatDate(dateString: string): string {
 }
 
 /** Map consultation type to Badge variant */
-function typeToBadgeVariant(type: string): 'standard' | 'webinar' | 'guidance' {
-  const mapping: Record<string, 'standard' | 'webinar' | 'guidance'> = {
+function typeToBadgeVariant(type: string): 'standard' | 'survey' | 'guidance' {
+  const mapping: Record<string, 'standard' | 'survey' | 'guidance'> = {
     'Exposure Draft': 'standard',
-    'Survey': 'webinar',
+    'Survey': 'survey',
     'Re-exposure Draft': 'guidance',
   }
   return mapping[type] || 'standard'

--- a/src/components/board/ProjectCard.tsx
+++ b/src/components/board/ProjectCard.tsx
@@ -50,11 +50,16 @@ type ProjectCardProps = {
 }
 
 /** Map badge type string to Badge component variant */
-function badgeTypeToVariant(type: string): 'standard' | 'consultation' | 'news' | 'webinar' | 'resource' | 'meeting' | 'guidance' {
-  const mapping: Record<string, 'standard' | 'consultation' | 'news' | 'webinar' | 'resource' | 'meeting' | 'guidance'> = {
+function badgeTypeToVariant(
+  type: string,
+): 'standard' | 'consultation' | 'news' | 'survey' | 'resource' | 'meeting' | 'guidance' {
+  const mapping: Record<
+    string,
+    'standard' | 'consultation' | 'news' | 'survey' | 'resource' | 'meeting' | 'guidance'
+  > = {
     'Exposure Draft': 'standard',
     'Public Comment': 'consultation',
-    'Survey': 'webinar',
+    'Survey': 'survey',
     'Research': 'resource',
     'Re-exposure Draft': 'guidance',
   }

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -34,6 +34,7 @@ type BadgeVariant =
   | 'decision'
   | 'deadline'
   | 'resource'
+  | 'survey'
 
 type BadgeProps = {
   variant: BadgeVariant
@@ -51,6 +52,7 @@ const variantClasses: Record<BadgeVariant, string> = {
   decision: 'bg-badge-decision text-white',
   deadline: 'bg-badge-deadline text-white',
   resource: 'bg-badge-resource text-white',
+  survey: 'bg-badge-survey text-white',
 }
 
 export function Badge({ variant, children, className = '' }: BadgeProps) {


### PR DESCRIPTION
## Summary
- Survey projects (and consultations) rendered with the webinar token (teal) which is semantically wrong — a survey is feedback collection, not a recorded webinar.
- Added a dedicated \`--color-badge-survey\` amber token to the \`@theme inline\` block in \`globals.css\`, exposed it via the \`Badge\` component variant union, and updated the three call sites (\`ProjectCard\` / \`ConsultationCard\` / \`ContentTypeBadge\`) to map Survey to the new variant.

## Test plan
- [x] \`npx tsc --noEmit\`
- [x] \`npx vitest run\` (42 files / 250 tests pass)
- [ ] Manual: visit \`/en/active-projects\` and confirm Survey badges render amber, not teal.

Closes #124
Tracked under #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)