### PR TITLE
fix(frontend): hide search Sort dropdown on empty results

### DIFF
--- a/src/app/(frontend)/[locale]/(frontend)/search/SearchPageClient.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/search/SearchPageClient.tsx
@@ -145,14 +145,17 @@ function ResultsStats() {
   )
 }
 
-/** Sort dropdown */
+/** Sort dropdown — hidden when there are no hits, since sort is a no-op against an empty result set */
 function SortControl() {
+  const { nbHits } = useStats()
   const { currentRefinement, options, refine } = useSortBy({
     items: [
       { label: 'Relevance', value: 'news_en' },
       { label: 'Date (newest first)', value: 'news_en:date:desc' },
     ],
   })
+
+  if (nbHits === 0) return null
 
   return (
     <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- \`SortControl\` now reads \`nbHits\` from \`useStats\` and renders \`null\` when there are zero results — no dead widget above the empty state.

## Test plan
- [x] \`npx tsc --noEmit\`
- [x] \`npx vitest run\` (250 tests pass)
- [ ] Manual: \`/en/search?q=zzznoresults\` — Sort dropdown is gone; \`/en/search?q=board\` — Sort dropdown is still there.

Closes #127
Tracked under #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)