### PR TITLE
fix(frontend): contact form polish — intro fallback + responsive submit

### DIFF
--- a/src/app/(frontend)/[locale]/(frontend)/contact-us/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/contact-us/page.tsx
@@ -57,11 +57,18 @@ export default async function ContactUsPage() {
           {page?.title || 'Contact Us'}
         </h1>
 
-        {/* Intro Text */}
-        {page?.hero?.richText && (
+        {/* Intro Text — prefer CMS-authored richText, fall back to a default
+            so the page never jumps from the H1 straight into form fields. */}
+        {page?.hero?.richText ? (
           <div className="prose max-w-none text-text-secondary">
             <RichText content={page.hero.richText as unknown as Record<string, unknown>} />
           </div>
+        ) : (
+          <p className="text-base text-text-secondary md:text-lg">
+            Send us a question, comment, or media inquiry. Submissions are
+            routed to the relevant team and we typically respond within five
+            business days. For media inquiries, see the contact details below.
+          </p>
         )}
 
         {/* Contact Form with ReCaptcha */}

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -230,7 +230,7 @@ export function ContactForm({ action, getRecaptchaToken, ...props }: ContactForm
         type="submit"
         variant="primary"
         size="lg"
-        className="w-full uppercase"
+        className="w-full sm:w-auto sm:max-w-xs uppercase"
         disabled={isPending}
         data-testid="contact-form-submit"
       >


### PR DESCRIPTION
## Summary
- /en/contact-us now renders a default intro paragraph when the CMS page record has no \`hero.richText\`, so visitors aren't dropped straight from the H1 into the first form field.
- Submit button class swap: \`w-full\` → \`w-full sm:w-auto sm:max-w-xs\` so it keeps the mobile tap-target but reads as a normal-width action on desktop.

## Test plan
- [x] \`npx tsc --noEmit\`
- [x] \`npx vitest run\` (250 tests pass)
- [ ] Manual: \`/en/contact-us\` shows the intro paragraph; submit button is full-width on mobile, narrow on desktop.

Closes #126
Tracked under #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)