### PR TITLE
fix(frontend): per-board color accent on board landing header

### DIFF
--- a/src/components/board/BoardLanding.tsx
+++ b/src/components/board/BoardLanding.tsx
@@ -50,6 +50,30 @@ function formatDate(value: string, locale: string): string {
   })
 }
 
+/**
+ * Per CLAUDE.md "Board-specific colors": each board surface gets a tinted
+ * accent so AcSB/AASB (red-brown), PSAB/CSSB (blue), and the FRAS umbrella
+ * (purple) read as visually distinct.
+ *
+ * Returned class names are static so Tailwind v4 picks them up at build time
+ * — never compose the slug into the class string at runtime.
+ */
+function boardAccent(slug: string): { border: string; heading: string } {
+  switch (slug) {
+    case 'acsb':
+    case 'aasb':
+      // Standard-setting boards
+      return { border: 'border-board-boards', heading: 'text-board-boards' }
+    case 'psab':
+    case 'cssb':
+      // Councils
+      return { border: 'border-board-councils', heading: 'text-board-councils' }
+    default:
+      // FRAS umbrella + RASOC oversight + any future record
+      return { border: 'border-board-fras', heading: 'text-board-fras' }
+  }
+}
+
 export async function BoardLanding({ board, locale }: BoardLandingProps) {
   const payloadLocale: PayloadLocale = toPayloadLocale(locale)
   const [news, allProjects] = await Promise.all([
@@ -73,12 +97,18 @@ export async function BoardLanding({ board, locale }: BoardLandingProps) {
     (a): a is NonNullable<typeof a> => Boolean(a),
   )
 
+  const accent = boardAccent(board.slug)
+
   return (
     <div className="mx-auto max-w-[1440px] px-4 py-8 sm:px-6 lg:px-8" data-testid="page-board-detail">
       <Breadcrumb items={breadcrumbItems} />
 
-      <header className="mt-4 border-b border-gray-200 pb-6">
-        <h1 className="text-3xl font-bold text-primary md:text-4xl">
+      <header
+        className={`mt-4 border-b-4 ${accent.border} pb-6`}
+        data-testid="board-landing-header"
+        data-board-accent={board.slug}
+      >
+        <h1 className={`text-3xl font-bold ${accent.heading} md:text-4xl`}>
           {board.abbreviation ? `${board.abbreviation} — ${board.name}` : board.name}
         </h1>
         {board.description && (


### PR DESCRIPTION
## Summary
- Added a \`boardAccent(slug)\` helper in \`BoardLanding.tsx\` that maps each board to its CLAUDE.md design token: \`acsb\`/\`aasb\` → \`board-boards\` (red-brown), \`psab\`/\`cssb\` → \`board-councils\` (blue), default → \`board-fras\` (purple).
- The board landing header H1 now uses the accented text color and the header gets a 4px bottom border in the same accent — replaces the previous flat \`border-b border-gray-200\` + \`text-primary\`.
- Class names are listed statically (no string concat) so Tailwind v4 picks them up at build time.

## Test plan
- [x] \`npx tsc --noEmit\`
- [x] \`npx vitest run\` (250 tests pass)
- [ ] Manual: visit \`/en/acsb\`, \`/en/psab\`, \`/en/aasb\`, \`/en/cssb\` — each header reads in its board color.

Closes #125
Tracked under #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)