### PR TITLE
fix(frontend): exclude RASOC at the boards loader

### DIFF
--- a/src/app/(frontend)/[locale]/(frontend)/active-projects/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/active-projects/page.tsx
@@ -24,7 +24,7 @@ import { PageHeader } from '@/components/PageHeader'
 import { FolderOpenIcon } from '@heroicons/react/24/outline'
 import {
   getAllActiveProjects,
-  getAllBoards,
+  getActiveBoards,
   getAllStandards,
   toPayloadLocale,
 } from '@/lib/payload-helpers'
@@ -48,19 +48,17 @@ export default async function ActiveProjectsPage({ params }: PageProps) {
   // Fetch data in parallel
   const [projects, boards, standards] = await Promise.all([
     getAllActiveProjects(toPayloadLocale(locale)),
-    getAllBoards(toPayloadLocale(locale)),
+    getActiveBoards(toPayloadLocale(locale)),
     getAllStandards(toPayloadLocale(locale)),
   ])
 
-  // Filter out RASOC from board nav
-  const navBoards = boards
-    .filter((b) => b.slug !== 'rasoc')
-    .map((b) => ({
-      id: String(b.id),
-      name: b.name,
-      slug: b.slug,
-      abbreviation: b.abbreviation,
-    }))
+  // RASOC is excluded at the data layer via getActiveBoards (#78).
+  const navBoards = boards.map((b) => ({
+    id: String(b.id),
+    name: b.name,
+    slug: b.slug,
+    abbreviation: b.abbreviation,
+  }))
 
   // Transform standards for filter dropdown
   const standardOptions = standards.map((s) => ({

--- a/src/app/(frontend)/[locale]/(frontend)/boards/[board-slug]/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/boards/[board-slug]/page.tsx
@@ -24,7 +24,7 @@ import { notFound } from 'next/navigation'
 import { Breadcrumb } from '@/components/layout/Breadcrumb'
 import {
   getBoardBySlug,
-  getAllBoards,
+  getActiveBoards,
   getProjectsByBoard,
   getNewsByBoard,
   getEventsByBoard,
@@ -38,12 +38,10 @@ type PageProps = {
   params: Promise<{ locale: string; 'board-slug': string }>
 }
 
-/** Pre-generate pages for 4 boards (excluding RASOC) */
+/** Pre-generate pages for 4 boards (excluding RASOC at the data layer per #78). */
 export async function generateStaticParams() {
-  const boards = await getAllBoards()
-  return boards
-    .filter((b) => b.slug !== 'rasoc')
-    .map((b) => ({ 'board-slug': b.slug }))
+  const boards = await getActiveBoards()
+  return boards.map((b) => ({ 'board-slug': b.slug }))
 }
 
 /** Dynamic metadata from board data */

--- a/src/app/(frontend)/[locale]/(frontend)/open-consultations/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/open-consultations/page.tsx
@@ -25,7 +25,7 @@ import { PageHeader } from '@/components/PageHeader'
 import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline'
 import {
   getOpenConsultations,
-  getAllBoards,
+  getActiveBoards,
   getAllStandards,
   toPayloadLocale,
 } from '@/lib/payload-helpers'
@@ -48,14 +48,12 @@ export default async function OpenConsultationsPage({ params }: PageProps) {
   const { locale } = await params
   const [consultations, boards, standards] = await Promise.all([
     getOpenConsultations(toPayloadLocale(locale)),
-    getAllBoards(toPayloadLocale(locale)),
+    getActiveBoards(toPayloadLocale(locale)),
     getAllStandards(toPayloadLocale(locale)),
   ])
 
-  // Filter RASOC from board filter
-  const boardOptions = boards
-    .filter((b) => b.slug !== 'rasoc')
-    .map((b) => ({ id: String(b.id), name: b.name, slug: b.slug }))
+  // RASOC is excluded at the data layer via getActiveBoards (#78).
+  const boardOptions = boards.map((b) => ({ id: String(b.id), name: b.name, slug: b.slug }))
 
   const standardOptions = standards.map((s) => ({
     id: String(s.id),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -17,7 +17,7 @@
  * - Each URL includes alternates for both EN and FR locales
  */
 import type { MetadataRoute } from 'next'
-import { getAllBoards, getAllActiveProjects, getAllStandardsSections } from '@/lib/payload-helpers'
+import { getActiveBoards, getAllActiveProjects, getAllStandardsSections } from '@/lib/payload-helpers'
 import { locales } from '@/i18n/routing'
 
 const BASE_URL = process.env.NEXT_PUBLIC_SERVER_URL || 'https://frascanada.ca'
@@ -54,9 +54,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     })),
   )
 
-  // Dynamic board pages (exclude RASOC — no board detail page)
-  const boards = await getAllBoards()
-  const nonOversightBoards = boards.filter((b) => b.slug !== 'rasoc')
+  // Dynamic board pages (exclude RASOC — no board detail page; #78).
+  const nonOversightBoards = await getActiveBoards()
 
   const boardRoutes: MetadataRoute.Sitemap = nonOversightBoards.flatMap((board) => {
     const path = `/boards/${board.slug}`

--- a/src/lib/payload-helpers.activeBoards.test.ts
+++ b/src/lib/payload-helpers.activeBoards.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { findMock } = vi.hoisted(() => ({
+  findMock: vi.fn(),
+}))
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn(async () => ({ find: findMock })),
+}))
+
+vi.mock('@payload-config', () => ({ default: {} }))
+
+import { getActiveBoards } from './payload-helpers'
+
+describe('getActiveBoards', () => {
+  beforeEach(() => {
+    findMock.mockReset()
+  })
+
+  it('queries the boards collection with a where filter excluding the RASOC abbreviation', async () => {
+    findMock.mockResolvedValueOnce({
+      docs: [
+        { id: 1, abbreviation: 'AcSB' },
+        { id: 2, abbreviation: 'PSAB' },
+        { id: 3, abbreviation: 'AASB' },
+        { id: 4, abbreviation: 'CSSB' },
+      ],
+    })
+
+    const boards = await getActiveBoards('en')
+
+    expect(boards).toHaveLength(4)
+    expect(findMock).toHaveBeenCalledTimes(1)
+    expect(findMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'boards',
+        where: { abbreviation: { not_equals: 'RASOC' } },
+      }),
+    )
+  })
+
+  it('passes the FR locale through so localized name/slug fields come back in French', async () => {
+    findMock.mockResolvedValueOnce({ docs: [] })
+
+    await getActiveBoards('fr')
+
+    expect(findMock).toHaveBeenCalledWith(expect.objectContaining({ locale: 'fr' }))
+  })
+
+  it('filter is keyed on the non-localized abbreviation field, so RASOC is excluded on FR too', async () => {
+    findMock.mockResolvedValueOnce({ docs: [] })
+
+    await getActiveBoards('fr')
+
+    const callArgs = findMock.mock.calls[0]?.[0] as Record<string, unknown>
+    // The whole point of #78 — never re-introduce a slug-keyed filter that
+    // would need a per-locale literal to catch the FR RASOC slug.
+    expect(callArgs.where).toEqual({ abbreviation: { not_equals: 'RASOC' } })
+  })
+
+  it('returns an empty array when Payload throws (defensive)', async () => {
+    findMock.mockRejectedValueOnce(new Error('db down'))
+
+    const boards = await getActiveBoards()
+
+    expect(boards).toEqual([])
+  })
+})

--- a/src/lib/payload-helpers.ts
+++ b/src/lib/payload-helpers.ts
@@ -253,6 +253,33 @@ export async function getAllBoards(locale: PayloadLocale = 'en'): Promise<Board[
 }
 
 /**
+ * Fetches the standards-setting boards/councils only — i.e. every board EXCEPT
+ * RASOC, the oversight council. Per CLAUDE.md "RASOC Rules", RASOC must not
+ * appear in board nav, the Active Projects sidebar, the open-consultations
+ * filter, or the boards [board-slug] static-params set.
+ *
+ * The exclusion runs at the data layer (Payload `where` filter on the
+ * non-localized `abbreviation` field) so it can't drift between locales —
+ * the previous in-component `b.slug !== 'rasoc'` filter was matching the
+ * EN slug literal and leaked RASOC into FR routes (#78).
+ */
+export async function getActiveBoards(locale: PayloadLocale = 'en'): Promise<Board[]> {
+  try {
+    const payload = await getPayload({ config })
+    const result = await payload.find({
+      collection: 'boards',
+      where: { abbreviation: { not_equals: 'RASOC' } },
+      limit: 100,
+      sort: 'name',
+      locale,
+    })
+    return result.docs as unknown as Board[]
+  } catch {
+    return []
+  }
+}
+
+/**
  * Fetches projects filtered by board, with populated relationships.
  */
 export async function getProjectsByBoard(boardId: number, limit = 20, locale: PayloadLocale = 'en'): Promise<Project[]> {


### PR DESCRIPTION
## Summary
- Added \`getActiveBoards(locale)\` to \`payload-helpers.ts\` — filters at the Payload \`where\` level on the non-localized \`abbreviation\` field (\`not_equals: 'RASOC'\`), so the exclusion can't drift between EN and FR.
- Replaced every per-call-site \`.filter(b => b.slug !== 'rasoc')\` (which matched the EN literal and leaked RASOC into FR routes) with a single call to the new helper. Touched: \`active-projects/page.tsx\`, \`boards/[board-slug]/page.tsx\` (\`generateStaticParams\`), \`open-consultations/page.tsx\`, \`sitemap.ts\`.
- Added \`payload-helpers.activeBoards.test.ts\` (4 tests) pinning the collection name, the exact \`where\` clause, locale pass-through, and a regression guard against ever reverting to a slug-keyed filter.

## Test plan
- [x] \`npx tsc --noEmit\`
- [x] \`npx vitest run\` (44 files / 259 tests pass)
- [ ] Manual: \`/fr/active-projects\` sidebar lists 4 boards (no RASOC); \`/fr/open-consultations\` filter dropdown lists 4; sitemap.xml has no \`/fr/<rasoc-fr-slug>\` entry.

Closes #78
Tracked under #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)