### PR TITLE
fix(frontend): bind locale explicitly to next-intl on FR routes (#77 follow-up)

### DIFF
--- a/src/app/(frontend)/[locale]/(frontend)/active-projects/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/active-projects/page.tsx
@@ -46,12 +46,16 @@ type PageProps = {
 
 export default async function ActiveProjectsPage({ params }: PageProps) {
   const { locale } = await params
-  // Fetch data + i18n strings in parallel
+  // Fetch data + i18n strings in parallel.
+  // We pass `locale` explicitly to getTranslations because the project does
+  // not call setRequestLocale anywhere, and without it next-intl's request
+  // context falls through to the default locale (en) on FR routes — leaking
+  // English copy into the FR page header. (#77)
   const [projects, boards, standards, tProjects] = await Promise.all([
     getAllActiveProjects(toPayloadLocale(locale)),
     getActiveBoards(toPayloadLocale(locale)),
     getAllStandards(toPayloadLocale(locale)),
-    getTranslations('projects'),
+    getTranslations({ locale, namespace: 'projects' }),
   ])
 
   // RASOC is excluded at the data layer via getActiveBoards (#78).

--- a/src/app/(frontend)/[locale]/(frontend)/layout.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/layout.tsx
@@ -69,19 +69,26 @@ export default async function FrontendLayout({ children, params }: LayoutProps) 
     notFound()
   }
 
-  // Fetch navigation, footer, search config, and messages in parallel
+  // Fetch navigation, footer, search config, and messages in parallel.
+  // Pass `locale` explicitly to getMessages — the project doesn't call
+  // setRequestLocale anywhere, and without it next-intl's request context
+  // can fall through to the default locale on FR routes, which would feed
+  // the EN dictionary into NextIntlClientProvider and leak EN strings into
+  // every client component that reads from useTranslations. (#77)
   const [navigation, footer, searchConfig, messages] = await Promise.all([
     getNavigation(toPayloadLocale(locale)),
     getFooter(toPayloadLocale(locale)),
     getSearchConfig(toPayloadLocale(locale)),
-    getMessages(),
+    getMessages({ locale }),
   ])
 
   return (
     <html lang={locale} className={inter.variable}>
       <body className="bg-page text-text-primary font-sans antialiased">
         <ClerkProvider localization={RAS_CLERK_LOCALIZATION}>
-          <NextIntlClientProvider messages={messages}>
+          {/* Hand the locale to the client provider so useTranslations
+              picks the right dictionary in every descendant. */}
+          <NextIntlClientProvider locale={locale} messages={messages}>
             <SiteHeader
               navigation={navigation}
               popularTags={searchConfig?.popular_tags as { label: string; query: string; id?: string }[] | null | undefined}


### PR DESCRIPTION
## Summary
Audit of #140 found that \`useTranslations\` / \`getTranslations\` were returning English on \`/fr/*\` routes despite the dictionaries being correct.

**Root cause:** this project never calls \`setRequestLocale\`, so next-intl's request context falls through to \`defaultLocale: 'en'\`. \`getMessages()\` then handed the EN dictionary to \`NextIntlClientProvider\`, which leaked EN strings into every client component that reads from \`useTranslations\` — and \`getTranslations()\` in async server components had the same issue.

**Fix:**
- Layout passes \`{ locale }\` to \`getMessages\` and explicit \`locale={locale}\` to \`<NextIntlClientProvider>\`, so every client descendant resolves against the correct dictionary.
- \`ActiveProjectsPage\` passes \`{ locale, namespace }\` to \`getTranslations\` as defence-in-depth for server-rendered copy.

## Test plan
- [x] \`npx tsc --noEmit\`
- [x] \`npx vitest run\` (45 files / 263 tests pass)
- [x] Live curl on \`/fr/active-projects\`:
  - PageHeader: \"Projets actifs\" / \"Parcourez les projets de normalisation actifs de tous les conseils.\"
  - \"All Boards\" / \"All Standards\" / \"Filter projects by name\" → 0 occurrences in HTML
- [x] Live curl on \`/en/active-projects\`: still renders English (no regression)

Tracked under #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)