### PR TITLE
fix(frontend): wire ContactForm + contact-us page through next-intl (#152)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -159,7 +159,24 @@
     "sending": "Sending...",
     "success": "Form submitted successfully.",
     "error": "An error occurred. Please try again.",
-    "validationError": "Please fix the errors below."
+    "validationError": "Please fix the errors below.",
+    "fullName": "Full Name *",
+    "titleField": "Title",
+    "emailAddress": "Email Address *",
+    "businessPhone": "Business Phone",
+    "comments": "Comments *",
+    "fullNameRequired": "Full Name is required.",
+    "emailRequired": "Email Address is required.",
+    "emailInvalid": "Please enter a valid email address.",
+    "commentsRequired": "Comments are required.",
+    "submitting": "Submitting...",
+    "correctErrors": "Please correct {count} error{plural} in the form."
+  },
+  "contact": {
+    "introFallback": "Send us a question, comment, or media inquiry. Submissions are routed to the relevant team and we typically respond within five business days. For media inquiries, see the contact details below.",
+    "metaTitle": "Contact Us — RAS Canada",
+    "metaDescription": "Get in touch with RAS Canada. Send us your questions, comments, or media inquiries.",
+    "mediaInquiriesHeading": "Media Inquiries"
   },
   "breadcrumb": {
     "home": "Home",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -159,7 +159,24 @@
     "sending": "Envoi en cours...",
     "success": "Formulaire soumis avec succes.",
     "error": "Une erreur est survenue. Veuillez reessayer.",
-    "validationError": "Veuillez corriger les erreurs ci-dessous."
+    "validationError": "Veuillez corriger les erreurs ci-dessous.",
+    "fullName": "Nom complet *",
+    "titleField": "Titre",
+    "emailAddress": "Adresse courriel *",
+    "businessPhone": "Telephone professionnel",
+    "comments": "Commentaires *",
+    "fullNameRequired": "Le nom complet est obligatoire.",
+    "emailRequired": "L'adresse courriel est obligatoire.",
+    "emailInvalid": "Veuillez entrer une adresse courriel valide.",
+    "commentsRequired": "Les commentaires sont obligatoires.",
+    "submitting": "Envoi en cours...",
+    "correctErrors": "Veuillez corriger {count} erreur{plural} dans le formulaire."
+  },
+  "contact": {
+    "introFallback": "Envoyez-nous une question, un commentaire ou une demande des medias. Les soumissions sont acheminees a l'equipe concernee et nous repondons habituellement dans un delai de cinq jours ouvrables. Pour les demandes des medias, consultez les coordonnees ci-dessous.",
+    "metaTitle": "Nous joindre — NIFC Canada",
+    "metaDescription": "Communiquez avec NIFC Canada. Envoyez-nous vos questions, commentaires ou demandes des medias.",
+    "mediaInquiriesHeading": "Demandes des medias"
   },
   "breadcrumb": {
     "home": "Accueil",

--- a/src/app/(frontend)/[locale]/(frontend)/contact-us/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/contact-us/page.tsx
@@ -23,6 +23,7 @@
  * - Page content (title, intro, media inquiries) comes from CMS
  */
 import type { Metadata } from 'next'
+import { getTranslations } from 'next-intl/server'
 
 import { Container } from '@/components/ui/Container'
 import { ContactFormWrapper } from '@/components/ContactFormWrapper'
@@ -31,14 +32,29 @@ import { RichText } from '@/components/RichText'
 import { submitContactForm } from '@/actions/contact'
 import { getPageBySlug } from '@/lib/payload-helpers'
 
-export const metadata: Metadata = {
-  title: 'Contact Us — RAS Canada',
-  description: 'Get in touch with RAS Canada. Send us your questions, comments, or media inquiries.',
+type PageProps = {
+  params: Promise<{ locale: string }>
 }
 
-export default async function ContactUsPage() {
-  // Fetch page content from CMS
-  const page = await getPageBySlug('contact-us')
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { locale } = await params
+  const t = await getTranslations({ locale, namespace: 'contact' })
+  return {
+    title: t('metaTitle'),
+    description: t('metaDescription'),
+  }
+}
+
+export default async function ContactUsPage({ params }: PageProps) {
+  const { locale } = await params
+  // Fetch page content + i18n strings in parallel. We pass `locale`
+  // explicitly to getTranslations because the project does not call
+  // setRequestLocale anywhere (see PR #143).
+  const [page, tNav, tContact] = await Promise.all([
+    getPageBySlug('contact-us'),
+    getTranslations({ locale, namespace: 'nav' }),
+    getTranslations({ locale, namespace: 'contact' }),
+  ])
 
   // Extract media inquiries data from page (group fields, may not exist on Page type yet)
   const mediaInquiries = (page as unknown as Record<string, unknown>)?.mediaInquiries as {
@@ -54,7 +70,7 @@ export default async function ContactUsPage() {
       <div data-testid="page-contact-us" className="flex flex-col gap-10">
         {/* Page Title */}
         <h1 className="text-3xl font-bold text-text-primary md:text-4xl">
-          {page?.title || 'Contact Us'}
+          {page?.title || tNav('contactUs')}
         </h1>
 
         {/* Intro Text — prefer CMS-authored richText, fall back to a default
@@ -65,9 +81,7 @@ export default async function ContactUsPage() {
           </div>
         ) : (
           <p className="text-base text-text-secondary md:text-lg">
-            Send us a question, comment, or media inquiry. Submissions are
-            routed to the relevant team and we typically respond within five
-            business days. For media inquiries, see the contact details below.
+            {tContact('introFallback')}
           </p>
         )}
 
@@ -77,7 +91,7 @@ export default async function ContactUsPage() {
         {/* Media Inquiries Block */}
         {mediaInquiries?.contactName && (
           <MediaInquiriesBlock
-            heading={mediaInquiries.heading || 'Media Inquiries'}
+            heading={mediaInquiries.heading || tContact('mediaInquiriesHeading')}
             contactName={mediaInquiries.contactName}
             contactTitle={mediaInquiries.contactTitle || ''}
             contactEmail={mediaInquiries.contactEmail || ''}

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -23,6 +23,7 @@
 'use client'
 
 import React, { useActionState, useRef, useEffect, useTransition } from 'react'
+import { useTranslations } from 'next-intl'
 import { Input } from '@/components/ui/Input'
 import { Button } from '@/components/ui/Button'
 
@@ -46,23 +47,29 @@ const initialState: ContactFormState = {
   message: '',
 }
 
-function validateField(name: string, value: string): string {
-  switch (name) {
-    case 'fullName':
-      return value.trim() ? '' : 'Full Name is required.'
-    case 'email': {
-      if (!value.trim()) return 'Email Address is required.'
-      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-      return emailRegex.test(value) ? '' : 'Please enter a valid email address.'
+type Validator = (name: string, value: string) => string
+
+function makeValidator(t: (key: string) => string): Validator {
+  return (name, value) => {
+    switch (name) {
+      case 'fullName':
+        return value.trim() ? '' : t('fullNameRequired')
+      case 'email': {
+        if (!value.trim()) return t('emailRequired')
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+        return emailRegex.test(value) ? '' : t('emailInvalid')
+      }
+      case 'comments':
+        return value.trim() ? '' : t('commentsRequired')
+      default:
+        return ''
     }
-    case 'comments':
-      return value.trim() ? '' : 'Comments are required.'
-    default:
-      return ''
   }
 }
 
 export function ContactForm({ action, getRecaptchaToken, ...props }: ContactFormProps) {
+  const t = useTranslations('forms')
+  const validateField = React.useMemo(() => makeValidator(t), [t])
   const [state, formAction, isActionPending] = useActionState(action, initialState)
   const [isTransitionPending, startTransition] = useTransition()
   const isPending = isActionPending || isTransitionPending
@@ -156,14 +163,17 @@ export function ContactForm({ action, getRecaptchaToken, ...props }: ContactForm
       {/* Error announcement for screen readers */}
       {Object.keys(errors).length > 0 && (
         <div role="alert" className="sr-only">
-          Please correct {Object.keys(errors).length} error{Object.keys(errors).length > 1 ? 's' : ''} in the form.
+          {t('correctErrors', {
+            count: Object.keys(errors).length,
+            plural: Object.keys(errors).length > 1 ? 's' : '',
+          })}
         </div>
       )}
 
       <Input
         id="fullName"
         name="fullName"
-        label="Full Name *"
+        label={t('fullName')}
         type="text"
         required
         error={errors?.fullName}
@@ -173,7 +183,7 @@ export function ContactForm({ action, getRecaptchaToken, ...props }: ContactForm
       <Input
         id="title"
         name="title"
-        label="Title"
+        label={t('titleField')}
         type="text"
         onBlur={handleBlur}
       />
@@ -181,7 +191,7 @@ export function ContactForm({ action, getRecaptchaToken, ...props }: ContactForm
       <Input
         id="organization"
         name="organization"
-        label="Organization"
+        label={t('organization')}
         type="text"
         onBlur={handleBlur}
       />
@@ -189,7 +199,7 @@ export function ContactForm({ action, getRecaptchaToken, ...props }: ContactForm
       <Input
         id="email"
         name="email"
-        label="Email Address *"
+        label={t('emailAddress')}
         type="email"
         required
         error={errors?.email}
@@ -199,7 +209,7 @@ export function ContactForm({ action, getRecaptchaToken, ...props }: ContactForm
       <Input
         id="businessPhone"
         name="businessPhone"
-        label="Business Phone"
+        label={t('businessPhone')}
         type="tel"
         onBlur={handleBlur}
       />
@@ -207,7 +217,7 @@ export function ContactForm({ action, getRecaptchaToken, ...props }: ContactForm
       <Input
         id="comments"
         name="comments"
-        label="Comments *"
+        label={t('comments')}
         type="textarea"
         required
         rows={6}
@@ -234,7 +244,7 @@ export function ContactForm({ action, getRecaptchaToken, ...props }: ContactForm
         disabled={isPending}
         data-testid="contact-form-submit"
       >
-        {isPending ? 'Submitting...' : 'Submit'}
+        {isPending ? t('submitting') : t('submit')}
       </Button>
     </form>
   )


### PR DESCRIPTION
## Summary

- `ContactForm.tsx` (client) reads field labels, validation strings, and submit/submitting copy via `useTranslations('forms')`
- `contact-us/page.tsx` (server) reads H1 fallback, intro fallback, and media-inquiries heading via locale-explicit `getTranslations` (PR #143 pattern)
- Static `metadata` export replaced with localized `generateMetadata`
- Added 11 new `forms.*` keys + new `contact` namespace (4 keys) to both messages dicts

## Verification

- \`/fr/nous-joindre\` shows: Nom complet, Adresse courriel, Titre, Organisme, Telephone professionnel, Commentaires, Soumettre — zero EN matches
- \`/en/contact-us\` unchanged
- \`npx vitest run\` 327/327 (parity test green)
- \`npx tsc --noEmit\` clean

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)