### PR TITLE
fix(frontend): wire NewsGridBlock + ProjectTimeline through next-intl (#154)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -101,7 +101,8 @@
     "summary": "Summary",
     "keyProposals": "Key Proposals",
     "contacts": "Contacts",
-    "relatedDocuments": "Related Documents"
+    "relatedDocuments": "Related Documents",
+    "stage": "Stage"
   },
   "consultations": {
     "title": "Open Consultations",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -101,7 +101,8 @@
     "summary": "Resume",
     "keyProposals": "Propositions cles",
     "contacts": "Personnes-ressources",
-    "relatedDocuments": "Documents connexes"
+    "relatedDocuments": "Documents connexes",
+    "stage": "Etape"
   },
   "consultations": {
     "title": "Consultations ouvertes",

--- a/src/app/(frontend)/[locale]/(frontend)/[...slug]/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/[...slug]/page.tsx
@@ -130,7 +130,7 @@ export default async function CatchAllPage({ params }: PageProps) {
           {/* Page builder blocks */}
           {layout && layout.length > 0 && (
             <div className="prose prose-lg max-w-none prose-headings:text-primary prose-a:text-link">
-              <RenderBlocks blocks={layout as Array<{ blockType: string; [key: string]: unknown }>} />
+              <RenderBlocks blocks={layout as Array<{ blockType: string; [key: string]: unknown }>} locale={locale} />
             </div>
           )}
 

--- a/src/app/(frontend)/[locale]/(frontend)/job-opportunities/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/job-opportunities/page.tsx
@@ -31,7 +31,12 @@ export const metadata: Metadata = {
   description: 'Current job openings at RAS Canada. Browse volunteer and employment opportunities with Canadian accounting standards boards.',
 }
 
-export default async function JobOpportunitiesPage() {
+type PageProps = {
+  params: Promise<{ locale: string }>
+}
+
+export default async function JobOpportunitiesPage({ params }: PageProps) {
+  const { locale } = await params
   const page = await getPageBySlug('job-opportunities')
 
   // Extract page fields with fallbacks for when CMS data isn't seeded
@@ -49,7 +54,7 @@ export default async function JobOpportunitiesPage() {
       {/* Rich text intro content (body paragraphs) */}
       {layout.length > 0 && (
         <div className="prose prose-lg max-w-none prose-headings:text-primary prose-a:text-link mb-6">
-          <RenderBlocks blocks={layout as Array<{ blockType: string; [key: string]: unknown }>} />
+          <RenderBlocks blocks={layout as Array<{ blockType: string; [key: string]: unknown }>} locale={locale} />
         </div>
       )}
 

--- a/src/app/(frontend)/[locale]/(frontend)/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/page.tsx
@@ -65,7 +65,7 @@ export default async function HomePage({ params }: PageProps) {
     <div data-testid="page-homepage" className="min-h-screen">
       <OrganizationSchema />
       <RenderHero {...homepage.hero} />
-      <RenderBlocks blocks={homepage.layout} />
+      <RenderBlocks blocks={homepage.layout} locale={locale} />
     </div>
   )
 }

--- a/src/blocks/NewsGridBlock/Component.tsx
+++ b/src/blocks/NewsGridBlock/Component.tsx
@@ -20,6 +20,7 @@
  * - News items display board abbreviation, title, date
  */
 import React from 'react'
+import { getTranslations } from 'next-intl/server'
 
 import { Container, Button } from '@/components/ui'
 import { getLatestNews } from '@/lib/payload-helpers'
@@ -31,6 +32,8 @@ type NewsGridBlockProps = {
   populateBy?: 'collection' | 'selection' | null
   selectedNews?: Array<{ id: string; title: string; slug: string; publishedDate?: string; board?: { abbreviation?: string } }> | null
   blockType: 'newsGrid'
+  /** Forwarded by RenderBlocks so server-side translations resolve to the request locale (see PR #143). */
+  locale?: string
 }
 
 export const NewsGridBlockComponent: React.FC<NewsGridBlockProps> = async ({
@@ -39,7 +42,11 @@ export const NewsGridBlockComponent: React.FC<NewsGridBlockProps> = async ({
   show_view_all,
   populateBy = 'collection',
   selectedNews,
+  locale,
 }) => {
+  // Defaults to 'en' if RenderBlocks didn't forward a locale (e.g. legacy
+  // call sites). Once every page wires `locale={locale}` this fallback is dead.
+  const t = await getTranslations({ locale: locale ?? 'en', namespace: 'common' })
   // For 'collection' mode, fetch latest news from CMS
   // For 'selection' mode, use the manually curated selectedNews
   let newsItems: Array<{ id: string; title: string; slug: string; publishedDate?: string; board?: { abbreviation?: string } }> = []
@@ -71,7 +78,7 @@ export const NewsGridBlockComponent: React.FC<NewsGridBlockProps> = async ({
           )}
           {show_view_all && (
             <Button variant="ghost" href="/news">
-              View All
+              {t('viewAll')}
             </Button>
           )}
         </div>

--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -39,9 +39,12 @@ const blockComponents: Record<string, React.FC<Record<string, unknown>>> = {
 
 type RenderBlocksProps = {
   blocks: LayoutBlock[] | null | undefined
+  /** Forwarded to each block as `locale` so server-side blocks can read
+      locale-explicit translations without prop-drilling from every page. */
+  locale?: string
 }
 
-export const RenderBlocks: React.FC<RenderBlocksProps> = ({ blocks }) => {
+export const RenderBlocks: React.FC<RenderBlocksProps> = ({ blocks, locale }) => {
   if (!blocks?.length) return null
 
   return (
@@ -55,7 +58,7 @@ export const RenderBlocks: React.FC<RenderBlocksProps> = ({ blocks }) => {
 
         return (
           <div className="my-16 first:mt-0" key={index}>
-            <BlockComponent {...(block as unknown as Record<string, unknown>)} />
+            <BlockComponent {...(block as unknown as Record<string, unknown>)} locale={locale} />
           </div>
         )
       })}

--- a/src/components/board/ProjectTimeline.tsx
+++ b/src/components/board/ProjectTimeline.tsx
@@ -21,7 +21,10 @@
  * - Stages with phase_number === current_stage are in-progress
  * - Stages with phase_number > current_stage are not-started
  */
+'use client'
+
 import React from 'react'
+import { useTranslations } from 'next-intl'
 import { CheckIcon } from '@heroicons/react/24/solid'
 
 export type TimelineStage = {
@@ -58,11 +61,13 @@ function getStageStatus(phaseNumber: number, currentStage: number): StageStatus 
 }
 
 export function ProjectTimeline({ stages, currentStage, className = '' }: ProjectTimelineProps) {
+  const t = useTranslations('projects')
+
   if (stages.length === 0) return null
 
   return (
     <div className={`${className}`.trim()} data-testid="project-timeline">
-      <h2 className="mb-6 text-xl font-bold text-text-heading">Project Timeline</h2>
+      <h2 className="mb-6 text-xl font-bold text-text-heading">{t('timeline')}</h2>
       <div className="relative">
         {stages.map((stage, index) => {
           const status = getStageStatus(stage.phase_number, currentStage)
@@ -109,7 +114,7 @@ export function ProjectTimeline({ stages, currentStage, className = '' }: Projec
                       status === 'future' ? 'text-text-muted' : 'text-primary'
                     }`}
                   >
-                    Stage {stage.phase_number}
+                    {t('stage')} {stage.phase_number}
                   </span>
                   {stage.date && (
                     <time


### PR DESCRIPTION
## Summary

- `NewsGridBlock` (server) accepts a `locale` prop forwarded by `RenderBlocks` and reads \"View All\" via locale-explicit `getTranslations({ locale, namespace: 'common' })`.
- `RenderBlocks` accepts a `locale` prop and forwards it to every block component. Updated all three call sites (homepage, catch-all `[...slug]`, job-opportunities).
- `ProjectTimeline` is now a client component and reads \"Project Timeline\" + \"Stage\" via `useTranslations('projects')`.
- Adds new key `projects.stage` (Stage / Etape) to both messages dicts.

## Verification

- `/fr` NewsGrid shows \"Voir tout\" (was \"View All\")
- `/en/active-projects/aasb/qm-implementation` still renders Stage 1/2/3 + \"Project Timeline\" h2
- `/fr/projets-actifs/cnac/<project>` renders FR \"Calendrier du projet\" h2 (FR stage data is empty in seed; that's a content issue, not i18n)
- `npx vitest run` 327/327, `npx tsc --noEmit` clean

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)