### PR TITLE
fix(frontend): translate SiteFooter BOARDS / LEGAL column headers (#155)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -161,7 +161,9 @@
     "privacyPolicy": "Privacy Policy",
     "termsOfUse": "Terms of Use",
     "accessibility": "Accessibility",
-    "cookiePolicy": "Cookie Policy"
+    "cookiePolicy": "Cookie Policy",
+    "legal": "Legal",
+    "notConfigured": "Footer not configured."
   },
   "forms": {
     "required": "Required",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -161,7 +161,9 @@
     "privacyPolicy": "Politique de confidentialite",
     "termsOfUse": "Conditions d'utilisation",
     "accessibility": "Accessibilite",
-    "cookiePolicy": "Politique relative aux temoins"
+    "cookiePolicy": "Politique relative aux temoins",
+    "legal": "Mentions legales",
+    "notConfigured": "Pied de page non configure."
   },
   "forms": {
     "required": "Obligatoire",

--- a/src/app/(frontend)/[locale]/(frontend)/layout.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/layout.tsx
@@ -94,7 +94,7 @@ export default async function FrontendLayout({ children, params }: LayoutProps) 
               popularTags={searchConfig?.popular_tags as { label: string; query: string; id?: string }[] | null | undefined}
             />
             <main data-testid="main-content">{children}</main>
-            <SiteFooter footer={footer} />
+            <SiteFooter footer={footer} locale={locale} />
           </NextIntlClientProvider>
         </ClerkProvider>
       </body>

--- a/src/components/layout/SiteFooter.test.tsx
+++ b/src/components/layout/SiteFooter.test.tsx
@@ -1,25 +1,35 @@
 import { render, screen, within } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+// next-intl's server helpers require a request context that's not available
+// in jsdom. Map keys → "namespace.key" so the existing assertions keep
+// working (the legal heading falls back to "footer.legal", which still
+// matches the /Quick Links|Legal/i regex used below).
+vi.mock('next-intl/server', () => ({
+  getTranslations: async ({ namespace }: { namespace?: string } = {}) => {
+    return (key: string) => (namespace ? `${namespace}.${key}` : key)
+  },
+}))
 
 import { SiteFooter } from './SiteFooter'
 import { BRAND } from '@/config/brand'
 import type { Footer } from '@/payload-types'
 
 describe('<SiteFooter>', () => {
-  it('renders the copyright with BRAND.fullName (no legacy "Financial Reporting" prefix)', () => {
-    render(<SiteFooter footer={null} />)
+  it('renders the copyright with BRAND.fullName (no legacy "Financial Reporting" prefix)', async () => {
+    render(await SiteFooter({ footer: null }))
     const bar = screen.getByTestId('footer-copyright')
     expect(bar).toHaveTextContent(BRAND.fullName)
     expect(bar).not.toHaveTextContent('Financial Reporting')
   })
 
-  it('renders the current year in the copyright', () => {
-    render(<SiteFooter footer={null} />)
+  it('renders the current year in the copyright', async () => {
+    render(await SiteFooter({ footer: null }))
     const year = String(new Date().getFullYear())
     expect(screen.getByTestId('footer-copyright')).toHaveTextContent(year)
   })
 
-  it('does not render the "Quick Links" heading twice when both nav + legal are populated (#91)', () => {
+  it('does not render the "Quick Links" heading twice when both nav + legal are populated (#91)', async () => {
     // QA-021 regression: column 2 (CMS-driven nav shortcuts) and column 4
     // (the `quick_links` legal column) both used to show "Quick Links" as
     // the heading. The legal column was renamed to "Legal" so each footer
@@ -37,13 +47,16 @@ describe('<SiteFooter>', () => {
         { id: 'q-1', label: 'Privacy Policy', url: '/privacy' },
       ],
     } as unknown as Footer
-    render(<SiteFooter footer={footer} />)
+    render(await SiteFooter({ footer }))
     const main = screen.getByTestId('site-footer')
     const headings = within(main)
-      .getAllByText(/Quick Links|Legal/i)
+      .getAllByText(/Quick Links|footer\.legal|Legal/i)
       .map((el) => el.textContent?.trim())
-    // Exactly one "Quick Links" (the nav column) and exactly one "Legal".
+    // Exactly one "Quick Links" (the CMS-driven nav column) and exactly
+    // one Legal heading (the `quick_links` field column). The mock
+    // returns the namespaced key so we look for either "Legal" or
+    // "footer.legal" depending on whether translations resolve at runtime.
     expect(headings.filter((h) => h === 'Quick Links')).toHaveLength(1)
-    expect(headings.filter((h) => h === 'Legal')).toHaveLength(1)
+    expect(headings.filter((h) => h === 'Legal' || h === 'footer.legal')).toHaveLength(1)
   })
 })

--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -22,6 +22,7 @@
  * - Policy links are UI chrome (hardcoded structural links)
  */
 import React from 'react'
+import { getTranslations } from 'next-intl/server'
 import { Link } from '@/i18n/navigation'
 import { Container } from '@/components/ui'
 import { NewsletterCTA } from '@/components/NewsletterCTA'
@@ -30,10 +31,19 @@ import type { Footer } from '@/payload-types'
 
 type SiteFooterProps = {
   footer?: Footer | null
+  /** Forwarded by the layout so server-side translations resolve to the
+      request locale (see PR #143). Defaults to 'en' if a legacy caller
+      hasn't passed it through yet. */
+  locale?: string
 }
 
-export function SiteFooter({ footer }: SiteFooterProps) {
+export async function SiteFooter({ footer, locale }: SiteFooterProps) {
   const currentYear = new Date().getFullYear()
+  const resolvedLocale = locale ?? 'en'
+  const [tFooter, tNav] = await Promise.all([
+    getTranslations({ locale: resolvedLocale, namespace: 'footer' }),
+    getTranslations({ locale: resolvedLocale, namespace: 'nav' }),
+  ])
 
   const columns = footer?.columns || []
   const boardsLinks = footer?.boards_links || []
@@ -82,7 +92,7 @@ export function SiteFooter({ footer }: SiteFooterProps) {
             {hasBoards && (
               <div>
                 <p className="text-sm font-bold text-text-primary uppercase tracking-wide">
-                  Boards
+                  {tNav('boards')}
                 </p>
                 <ul className="mt-3 space-y-2">
                   {boardsLinks.map((board, i) => (
@@ -108,7 +118,7 @@ export function SiteFooter({ footer }: SiteFooterProps) {
             {hasQuickLinks && (
               <div>
                 <p className="text-sm font-bold text-text-primary uppercase tracking-wide">
-                  Legal
+                  {tFooter('legal')}
                 </p>
                 <ul className="mt-3 space-y-2">
                   {quickLinks.map((link, i) => (
@@ -132,7 +142,7 @@ export function SiteFooter({ footer }: SiteFooterProps) {
       {!hasAnyContent && (
         <Container>
           <div className="py-8 text-center text-sm text-text-muted">
-            Footer not configured.
+            {tFooter('notConfigured')}
           </div>
         </Container>
       )}


### PR DESCRIPTION
## Summary

- `SiteFooter` is now async server, accepts optional `locale` prop forwarded by the locale layout, and reads the two hardcoded column headers via `getTranslations` (PR #143 pattern)
  - "Boards" → `nav.boards` (existing)
  - "Legal" → `footer.legal` (new)
- Adds `footer.legal` and `footer.notConfigured` to both messages dicts
- Test mocks `next-intl/server` and awaits the async component

Out of scope (kept hardcoded): copyright string (still needs `BRAND.fullName` per PR #98) and policy links.

## Verification

- `/fr` footer: Conseils + Mentions legales (alongside the CMS-driven Normes + Liens rapides)
- `/en` footer: Boards + Legal unchanged
- `npx vitest run` 327/327, `npx tsc --noEmit` clean

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)