### PR TITLE
fix(frontend): translate hero search widget + global header search (#156)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -40,6 +40,9 @@
     "contactUs": "Contact Us",
     "careers": "Careers"
   },
+  "homepage": {
+    "findActiveProject": "Find an active project"
+  },
   "search": {
     "title": "Search Results",
     "placeholder": "Projects, standards, and more...",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -40,6 +40,9 @@
     "contactUs": "Nous joindre",
     "careers": "Carrieres"
   },
+  "homepage": {
+    "findActiveProject": "Trouver un projet actif"
+  },
   "search": {
     "title": "Resultats de recherche",
     "placeholder": "Projets, normes et plus...",

--- a/src/app/(frontend)/[locale]/(frontend)/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/page.tsx
@@ -64,7 +64,7 @@ export default async function HomePage({ params }: PageProps) {
   return (
     <div data-testid="page-homepage" className="min-h-screen">
       <OrganizationSchema />
-      <RenderHero {...homepage.hero} />
+      <RenderHero {...homepage.hero} locale={locale} />
       <RenderBlocks blocks={homepage.layout} locale={locale} />
     </div>
   )

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -24,6 +24,7 @@
 
 import React, { useState } from 'react'
 import dynamic from 'next/dynamic'
+import { useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 import { MagnifyingGlassIcon, Bars3Icon } from '@heroicons/react/24/outline'
 import { Container } from '@/components/ui'
@@ -94,6 +95,8 @@ function buildFlatMenuItems(
 }
 
 export function SiteHeader({ navigation, popularTags }: SiteHeaderProps) {
+  const tSearch = useTranslations('search')
+  const tNav = useTranslations('nav')
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [searchModalOpen, setSearchModalOpen] = useState(false)
 
@@ -160,7 +163,8 @@ export function SiteHeader({ navigation, popularTags }: SiteHeaderProps) {
               />
               <input
                 type="search"
-                placeholder="Projects, standards, and more..."
+                placeholder={tSearch('placeholder')}
+                aria-label={tSearch('ariaLabel')}
                 className="w-full rounded-sm border border-gray-300 bg-white py-2 pl-10 pr-4 text-sm placeholder:text-text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary-bright/30 cursor-pointer"
                 data-testid="header-search"
                 readOnly
@@ -175,7 +179,7 @@ export function SiteHeader({ navigation, popularTags }: SiteHeaderProps) {
               type="button"
               onClick={() => setSearchModalOpen(true)}
               className="rounded-sm p-2 text-text-muted hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-bright cursor-pointer"
-              aria-label="Search"
+              aria-label={tSearch('ariaLabel')}
               data-testid="mobile-search-toggle"
             >
               <MagnifyingGlassIcon className="h-6 w-6" aria-hidden="true" />
@@ -184,7 +188,7 @@ export function SiteHeader({ navigation, popularTags }: SiteHeaderProps) {
               type="button"
               onClick={() => setMobileMenuOpen(true)}
               className="rounded-sm p-2 text-text-muted hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-bright cursor-pointer"
-              aria-label="Open navigation menu"
+              aria-label={tNav('openMenu')}
               data-testid="mobile-menu-toggle"
             >
               <Bars3Icon className="h-6 w-6" aria-hidden="true" />

--- a/src/heros/HighImpact/index.tsx
+++ b/src/heros/HighImpact/index.tsx
@@ -21,6 +21,7 @@
  * - data-testid attributes for self-test compatibility
  */
 import React from 'react'
+import { getTranslations } from 'next-intl/server'
 
 import type { Page } from '@/payload-types'
 
@@ -28,13 +29,24 @@ import { Container } from '@/components/ui'
 import { CMSLink } from '@/components/CMSLink'
 import { RichText } from '@/components/RichText'
 
-type HighImpactHeroProps = Page['hero']
+type HighImpactHeroProps = Page['hero'] & {
+  /** Forwarded by RenderHero so server-side translations resolve to the
+      request locale (see PR #143). Defaults to 'en' if a legacy caller
+      hasn't passed it through yet. */
+  locale?: string
+}
 
-export const HighImpactHero: React.FC<HighImpactHeroProps> = ({
+export const HighImpactHero = async ({
   links,
   richText,
   search_enabled,
-}) => {
+  locale,
+}: HighImpactHeroProps) => {
+  const resolvedLocale = locale ?? 'en'
+  const [tHome, tSearch] = await Promise.all([
+    getTranslations({ locale: resolvedLocale, namespace: 'homepage' }),
+    getTranslations({ locale: resolvedLocale, namespace: 'search' }),
+  ])
   return (
     <section
       data-testid="hero-section"
@@ -64,13 +76,13 @@ export const HighImpactHero: React.FC<HighImpactHeroProps> = ({
               <div
                 className="flex-1 rounded-l-sm border border-white/30 bg-white/10 px-4 py-3 text-left text-white/60 backdrop-blur-sm"
               >
-                Find an active project
+                {tHome('findActiveProject')}
               </div>
               <button
                 type="button"
                 className="rounded-r-sm bg-dark px-6 py-3 font-semibold text-white transition-colors hover:bg-gray-800"
               >
-                Search
+                {tSearch('searchButton')}
               </button>
             </div>
           )}

--- a/src/heros/RenderHero.tsx
+++ b/src/heros/RenderHero.tsx
@@ -28,7 +28,13 @@ const heroComponents = {
   lowImpact: LowImpactHero,
 }
 
-export const RenderHero: React.FC<Page['hero']> = (props) => {
+type RenderHeroProps = Page['hero'] & {
+  /** Forwarded by callers so server-side hero variants can read
+      locale-explicit translations. Optional for backwards-compat. */
+  locale?: string
+}
+
+export const RenderHero: React.FC<RenderHeroProps> = (props) => {
   const { type } = props || {}
 
   if (!type || type === 'none') return null


### PR DESCRIPTION
## Summary

- `HighImpactHero` is async server, accepts `locale` from RenderHero, reads "Find an active project" + "Search" via `getTranslations` (PR #143 pattern)
- `RenderHero` forwards `locale`; homepage passes it through
- `SiteHeader` (client) reads the persistent search input placeholder + search/menu aria-labels via `useTranslations`
- Adds new `homepage` namespace (one key) to both messages dicts; reuses existing `search.placeholder` / `search.ariaLabel` / `search.searchButton` / `nav.openMenu`

## Verification

- `/fr` hero shows "Trouver un projet actif" + "Rechercher" button; header input placeholder is "Projets, normes et plus..."
- `/en` unchanged
- `npx vitest run` 327/327, `npx tsc --noEmit` clean

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)