### PR TITLE
fix(frontend): auto-prepend localized Home crumb in Breadcrumb (#157)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -203,7 +203,8 @@
     "activeProjects": "Active Projects",
     "openConsultations": "Open Consultations",
     "boards": "Boards",
-    "search": "Search"
+    "search": "Search",
+    "ariaLabel": "Breadcrumb"
   },
   "a11y": {
     "skipToContent": "Skip to main content",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -203,7 +203,8 @@
     "activeProjects": "Projets actifs",
     "openConsultations": "Consultations ouvertes",
     "boards": "Conseils",
-    "search": "Recherche"
+    "search": "Recherche",
+    "ariaLabel": "Fil d'Ariane"
   },
   "a11y": {
     "skipToContent": "Passer au contenu principal",

--- a/src/components/board/BoardLanding.test.tsx
+++ b/src/components/board/BoardLanding.test.tsx
@@ -19,6 +19,13 @@ vi.mock('next-intl/server', () => ({
   getTranslations: async () => (key: string) => key,
 }))
 
+// `<Breadcrumb>` is a child client component that calls useTranslations.
+// Without a NextIntlClientProvider in the test tree, the call throws —
+// stub the client API to return the key.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
 import { BoardLanding } from './BoardLanding'
 import type { Board } from '@/payload-types'
 

--- a/src/components/layout/Breadcrumb.tsx
+++ b/src/components/layout/Breadcrumb.tsx
@@ -22,6 +22,7 @@
 'use client'
 
 import React from 'react'
+import { useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 import { usePathname } from 'next/navigation'
 
@@ -31,7 +32,12 @@ export type BreadcrumbItem = {
 }
 
 type BreadcrumbProps = {
-  /** Optional manual breadcrumb items (overrides auto-generation) */
+  /** Optional manual breadcrumb items (overrides auto-generation).
+      Callers should NOT include a leading Home entry — the component
+      always prepends a localized Home crumb. Legacy callers passing
+      `{ label: 'Home', href: '/' }` as the first item are tolerated:
+      that entry is stripped and replaced with the localized version
+      so we don't render two Home crumbs. */
   items?: BreadcrumbItem[]
   className?: string
 }
@@ -48,12 +54,12 @@ function slugToLabel(slug: string): string {
 }
 
 /**
- * Auto-generates breadcrumb items from a URL pathname.
- * Always starts with "Home" -> "/" and builds from path segments.
+ * Auto-generates breadcrumb items from a URL pathname (without Home —
+ * the component prepends the localized Home crumb itself).
  */
 function generateFromPath(pathname: string): BreadcrumbItem[] {
   const segments = pathname.split('/').filter(Boolean)
-  const items: BreadcrumbItem[] = [{ label: 'Home', href: '/' }]
+  const items: BreadcrumbItem[] = []
 
   segments.forEach((segment, index) => {
     const href = '/' + segments.slice(0, index + 1).join('/')
@@ -69,14 +75,23 @@ function generateFromPath(pathname: string): BreadcrumbItem[] {
 }
 
 export function Breadcrumb({ items, className = '' }: BreadcrumbProps) {
+  const t = useTranslations('breadcrumb')
   const pathname = usePathname()
-  const breadcrumbItems = items ?? generateFromPath(pathname)
+  const provided = items ?? generateFromPath(pathname)
+
+  // Strip a leading Home entry from legacy callers so we never double-render.
+  const trail = provided[0]?.label === 'Home' ? provided.slice(1) : provided
+
+  const breadcrumbItems: BreadcrumbItem[] = [
+    { label: t('home'), href: '/' },
+    ...trail,
+  ]
 
   // Don't render breadcrumb on homepage
   if (breadcrumbItems.length <= 1) return null
 
   return (
-    <nav aria-label="Breadcrumb" className={`text-sm ${className}`.trim()} data-testid="breadcrumb">
+    <nav aria-label={t('ariaLabel')} className={`text-sm ${className}`.trim()} data-testid="breadcrumb">
       <ol className="flex flex-wrap items-center gap-1">
         {breadcrumbItems.map((item, index) => {
           const isLast = index === breadcrumbItems.length - 1


### PR DESCRIPTION
## Summary

Pattern A from the issue: `<Breadcrumb>` now owns the leading Home anchor and reads its label via `useTranslations('breadcrumb').home`. The component strips a legacy `{ label: 'Home', href: '/' }` first entry if a caller passes one (so we don't render two Home crumbs) and prepends the localized version.

- Auto-gen path no longer seeds an EN "Home"; prepend handles it
- `aria-label="Breadcrumb"` now reads from a new `breadcrumb.ariaLabel` key (Breadcrumb / Fil d'Ariane)
- All 12 legacy callers (page-level breadcrumbs) continue to work via the strip-and-prepend tolerance — no callsite changes needed
- `BoardLanding.test.tsx` adds a `next-intl` mock so the embedded client `<Breadcrumb>` resolves its hook in jsdom

## Verification

- `/fr/cnc`, `/fr/cnac`, `/fr/ccsp` breadcrumbs render "Accueil"
- `/en/acsb` breadcrumb renders "Home"
- `npx vitest run` 327/327, `npx tsc --noEmit` clean

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)