### PR TITLE
fix(frontend): --surface-card token + apply to sidebar widgets, board cards, browse-by-standard (#181)

### DIFF
--- a/src/app/(frontend)/[locale]/(frontend)/globals.css
+++ b/src/app/(frontend)/[locale]/(frontend)/globals.css
@@ -57,7 +57,14 @@
   --color-text-on-dark-muted: rgba(255, 255, 255, 0.82);
 
   /* ── Semantic: Background ── */
-  --color-page: #FFFFFF;
+  /* Page surface is a hair cooler/darker than pure white so elevated
+     `--color-surface-card` containers visibly float against it. The
+     gap is intentionally subtle (~2% luminance) to avoid a "blue-grey
+     wash" feel — see QA-202 / .ai-reports/dogfood-2026-05-03-light-mode. */
+  --color-page: #F7F7F9;
+  --color-surface-card: #FFFFFF;
+  --color-surface-card-hover: #FBFBFC;
+  --color-surface-card-border: #E6E6EA;
   --color-footer: #EEEEEE;
   --color-alt: #F5F5F5;
   --color-surface-light: #F8F8F8;
@@ -137,6 +144,11 @@
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
   --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
   --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
+  /* Card elevation — paired with --color-surface-card so widgets read
+     as floating against the cooler --color-page. Two stacked shadows:
+     a sharp 1px ambient + a softer 3px diffuse drop. (QA-202) */
+  --shadow-card: 0 1px 2px rgba(15, 23, 42, 0.04), 0 1px 3px rgba(15, 23, 42, 0.06);
+  --shadow-card-hover: 0 1px 2px rgba(15, 23, 42, 0.05), 0 4px 12px rgba(15, 23, 42, 0.08);
 
   /* ── Breakpoints ── */
   --breakpoint-sm: 640px;

--- a/src/blocks/BrowseByStandardBlock/Component.tsx
+++ b/src/blocks/BrowseByStandardBlock/Component.tsx
@@ -51,7 +51,7 @@ function CategoryCard({ category }: { category: Category }) {
   if (!category.name && populatedLinks.length === 0) return null
 
   return (
-    <div className="rounded-md border border-gray-200 bg-white">
+    <div className="rounded-md border border-surface-card-border bg-surface-card shadow-card transition-shadow hover:shadow-card-hover">
       {/* Desktop: always visible */}
       <div className="hidden md:block p-6">
         {category.name && (

--- a/src/components/board/BoardLanding.tsx
+++ b/src/components/board/BoardLanding.tsx
@@ -196,7 +196,7 @@ export async function BoardLanding({ board, locale }: BoardLandingProps) {
                 {activeProjects.map((project: Project) => (
                   <li
                     key={project.id}
-                    className="rounded-md border border-gray-200 p-4"
+                    className="rounded-md border border-surface-card-border bg-surface-card p-4 shadow-card transition-shadow hover:shadow-card-hover"
                     data-testid="active-project"
                   >
                     <Link
@@ -219,18 +219,20 @@ export async function BoardLanding({ board, locale }: BoardLandingProps) {
 
         <aside className="space-y-6 lg:sticky lg:top-8 lg:self-start" data-testid="right-rail">
           {quickActions.length > 0 && (
-            <QuickActions
-              actions={quickActions.map((a) => ({
-                label: a.label,
-                url: a.url,
-                icon: a.icon,
-              }))}
-            />
+            <div className="rounded-md border border-surface-card-border bg-surface-card p-4 shadow-card">
+              <QuickActions
+                actions={quickActions.map((a) => ({
+                  label: a.label,
+                  url: a.url,
+                  icon: a.icon,
+                }))}
+              />
+            </div>
           )}
 
           <nav
             aria-labelledby="board-section-links-heading"
-            className="rounded-md border border-gray-200 p-4"
+            className="rounded-md border border-surface-card-border bg-surface-card p-4 shadow-card"
           >
             <h2
               id="board-section-links-heading"


### PR DESCRIPTION
## Summary

Foundation for the dogfood-4 light-mode polish. Adds the elevated-surface tokens to `globals.css` under `@theme inline` (so Tailwind v4 generates the utilities automatically) and applies them to four high-impact surfaces.

**New tokens**
- `--color-page: #F7F7F9` (was #FFFFFF) — slightly cooler page surface
- `--color-surface-card: #FFFFFF` + `--color-surface-card-border: #E6E6EA` + `--color-surface-card-hover: #FBFBFC`
- `--shadow-card` + `--shadow-card-hover` — two-stop shadows (sharp 1px ambient + soft 3px diffuse), tuned for "subtly floating" not "popping"

**Applied to**
- `BoardLanding` Quick Actions sidebar (wrapped in a card div so it matches the About card visual weight)
- `BoardLanding` About sidebar nav
- `BoardLanding` active-project list cards (with hover affordance)
- `BrowseByStandardBlock` homepage cards (with hover affordance)

Other surfaces (resource cards, news cards, contact form wrapper) stay on `border-gray-200` for now — tracked under their respective dogfood-4 issues.

## Verification

- See after-screenshots in PR comment / `/tmp/after-issue-181-*.png` — page bg now reads as cooler grey, browse-by-standard cards visibly float
- `npx vitest run` 327/327, `npx tsc --noEmit` clean

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)