### PR TITLE
fix(frontend): bump BoardLanding sidebar widget gap to 32px (#184)

### DIFF
--- a/src/components/board/BoardLanding.tsx
+++ b/src/components/board/BoardLanding.tsx
@@ -217,7 +217,7 @@ export async function BoardLanding({ board, locale }: BoardLandingProps) {
           </section>
         </main>
 
-        <aside className="space-y-6 lg:sticky lg:top-8 lg:self-start" data-testid="right-rail">
+        <aside className="space-y-8 lg:sticky lg:top-8 lg:self-start" data-testid="right-rail">
           {quickActions.length > 0 && (
             <div className="rounded-md border border-surface-card-border bg-surface-card p-4 shadow-card">
               <QuickActions


### PR DESCRIPTION
Closes #184. Pairs with the --surface-card token (#181) to give the Quick Actions + About widgets clear vertical separation in the right rail. See /tmp/after-issue-184-scrolled.png.