### PR TITLE
fix(frontend): retire legacy 'Financial Reporting & Assurance Standards' string from metadata (#149)

### DIFF
--- a/src/app/(frontend)/[locale]/(frontend)/layout.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/layout.tsx
@@ -43,6 +43,7 @@ import { SiteHeader } from '@/components/layout/SiteHeader'
 import { SiteFooter } from '@/components/layout/SiteFooter'
 import { getNavigation, getFooter, getSearchConfig, toPayloadLocale } from '@/lib/payload-helpers'
 import { routing } from '@/i18n/routing'
+import { BRAND } from '@/config/brand'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -51,8 +52,17 @@ const inter = Inter({
   variable: '--font-inter',
 })
 
+// Default metadata for any route under [locale] that doesn't export its
+// own `generateMetadata`. Pulls the brand string from BRAND so the
+// legacy "Financial Reporting & Assurance Standards" copy can never
+// sneak back in via a stale string. The `template` lets every page
+// that does export `generateMetadata` provide a leading title segment
+// that gets " — RAS Canada" appended automatically. (#149 / QA-101)
 export const metadata: Metadata = {
-  title: 'RAS Canada — Financial Reporting & Assurance Standards',
+  title: {
+    default: `${BRAND.name} — ${BRAND.tagline}`,
+    template: `%s — ${BRAND.name}`,
+  },
   description:
     'The standard-setting body for all accountants across Canada. Home of AcSB, PSAB, AASB, and CSSB.',
 }

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -20,7 +20,11 @@ export function OrganizationSchema() {
     '@context': 'https://schema.org',
     '@type': 'Organization',
     name: 'RAS Canada',
-    alternateName: 'Financial Reporting & Assurance Standards Canada',
+    // Schema.org `alternateName` lists names the org also goes by. Use
+    // the canonical full name (Reporting and Assurance Standards (RAS)
+    // Canada) — the legacy "Financial Reporting" string is retired.
+    // (#149 / QA-101)
+    alternateName: 'Reporting and Assurance Standards (RAS) Canada',
     url: BASE_URL,
     description:
       'RAS Canada serves the public interest by establishing high-quality accounting, auditing, and sustainability standards for Canada.',

--- a/src/utilities/generateMeta.ts
+++ b/src/utilities/generateMeta.ts
@@ -16,6 +16,7 @@ import type { Metadata } from 'next'
 
 import { mergeOpenGraph } from './mergeOpenGraph'
 import { getServerSideURL } from './getURL'
+import { BRAND } from '@/config/brand'
 
 type MetaImage = {
   url?: string | null
@@ -50,9 +51,12 @@ export const generateMeta = async (args: { doc: MetaDoc | null }): Promise<Metad
 
   const ogImage = getImageURL(doc?.meta?.image ?? null)
 
+  // Title falls back to the canonical brand string from BRAND so the
+  // legacy "Financial Reporting & Assurance Standards" copy can't
+  // sneak back through this code path. (#149 / QA-101)
   const title = doc?.meta?.title
-    ? `${doc.meta.title} | RAS Canada`
-    : 'RAS Canada — Financial Reporting & Assurance Standards'
+    ? `${doc.meta.title} | ${BRAND.name}`
+    : `${BRAND.name} — ${BRAND.tagline}`
 
   return {
     description: doc?.meta?.description,

--- a/src/utilities/mergeOpenGraph.ts
+++ b/src/utilities/mergeOpenGraph.ts
@@ -14,18 +14,23 @@
 import type { Metadata } from 'next'
 
 import { getServerSideURL } from './getURL'
+import { BRAND } from '@/config/brand'
 
+// Default OG metadata applied by `mergeOpenGraph` when a page-level
+// override doesn't provide its own. Brand string is the canonical
+// `BRAND.fullName` — never the legacy "Financial Reporting &
+// Assurance Standards" copy. (#149 / QA-101)
 const defaultOpenGraph: Metadata['openGraph'] = {
   type: 'website',
   description:
-    'Financial Reporting & Assurance Standards Canada — the standard-setting body for all accountants across Canada.',
+    `${BRAND.fullName} — the standard-setting body for all accountants across Canada.`,
   images: [
     {
       url: `${getServerSideURL()}/og-default.png`,
     },
   ],
-  siteName: 'RAS Canada',
-  title: 'RAS Canada',
+  siteName: BRAND.name,
+  title: BRAND.name,
 }
 
 export const mergeOpenGraph = (og?: Metadata['openGraph']): Metadata['openGraph'] => {


### PR DESCRIPTION
Closes #149. Four metadata paths (layout default, mergeOpenGraph, generateMeta fallback, StructuredData alternateName) now pull from BRAND.* instead of hardcoding the pre-rebrand string. Live: /en/acsb /en/cssb /fr/cnc all render the canonical title. tsc + vitest 327/327 clean.