### PR TITLE
fix(frontend): preserve brand casing for board abbreviations everywhere (#158)

### DIFF
--- a/src/app/(frontend)/[locale]/(frontend)/open-consultations/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/open-consultations/page.tsx
@@ -72,7 +72,10 @@ export default async function OpenConsultationsPage({ params }: PageProps) {
       slug: c.slug,
       type: c.type,
       deadline_date: c.deadline_date,
-      boardName: board?.name || 'Unknown Board',
+      // Render the brand-cased abbreviation (AcSB / AASB / etc.) — the
+      // rest of the UI uses abbreviations, so showing the full board
+      // name on consultation cards reads as inconsistent. (#158 / QA-110)
+      boardName: board?.abbreviation || board?.name || 'Unknown Board',
       boardSlug: board?.slug || '',
       standardName: standard?.name || null,
       description: null as string | null,

--- a/src/blocks/NewsGridBlock/Component.tsx
+++ b/src/blocks/NewsGridBlock/Component.tsx
@@ -89,7 +89,9 @@ export const NewsGridBlockComponent: React.FC<NewsGridBlockProps> = async ({
             {newsItems.slice(0, news_count || 3).map((item) => (
               <li key={item.id} className="border-b border-gray-200 pb-4 last:border-0">
                 {item.board?.abbreviation && (
-                  <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+                  // No `uppercase` — board.abbreviation is brand-cased
+                  // (AcSB / AASB) and CSS uppercase mangles it. (#158)
+                  <p className="text-xs font-bold tracking-[0.16em] text-text-muted">
                     {item.board.abbreviation}
                   </p>
                 )}

--- a/src/components/board/BoardNav.tsx
+++ b/src/components/board/BoardNav.tsx
@@ -111,7 +111,7 @@ export function BoardNav({
           <option value="">{tFilters('allBoards')}</option>
           {boards.map((board) => (
             <option key={board.slug} value={board.slug}>
-              {board.name}
+              {board.abbreviation || board.name}
             </option>
           ))}
         </select>

--- a/src/components/board/SectionNav.tsx
+++ b/src/components/board/SectionNav.tsx
@@ -72,7 +72,11 @@ export function SectionNav({
       {/* Desktop: vertical nav list (hidden below lg) */}
       <div className="hidden lg:block sticky top-8">
         {boardName && (
-          <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-text-muted">
+          // No `uppercase` utility — boardName comes in as a brand-cased
+          // abbreviation (AcSB / AASB / etc.) and CSS uppercase mangles
+          // it to ACSB. Use letter-spacing for the small-caps emphasis
+          // instead. (#158 / QA-110)
+          <p className="mb-3 text-xs font-bold tracking-[0.18em] text-text-muted">
             {boardName}
           </p>
         )}
@@ -103,7 +107,7 @@ export function SectionNav({
       {/* Mobile: dropdown selector (visible below lg) */}
       <div className="lg:hidden">
         {boardName && (
-          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-text-muted">
+          <p className="mb-2 text-xs font-bold tracking-[0.18em] text-text-muted">
             {boardName}
           </p>
         )}


### PR DESCRIPTION
Closes #158. Two anti-patterns swept: CSS `uppercase` mangling 'AcSB' → 'ACSB' (SectionNav, NewsGridBlock), and rendering `board.name` where the rest of the UI uses abbreviations (Open Consultations cards, BoardNav mobile dropdown). Live verify: /en/active-projects/acsb/crypto-assets renders 'AcSB' (was 'ACSB').