### PR TITLE
feat(search): SearchProvider abstraction (Algolia Slice 1, #172)

### DIFF
--- a/src/app/(frontend)/[locale]/(frontend)/search/SearchPageClient.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/search/SearchPageClient.tsx
@@ -30,8 +30,9 @@
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import { useSearchParams } from 'next/navigation'
-import { useTranslations } from 'next-intl'
-import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
+import { useLocale, useTranslations } from 'next-intl'
+import { getSearchProvider } from '@/search'
+import type { ProviderLocale } from '@/search/types'
 import {
   InstantSearch,
   useSearchBox,
@@ -380,14 +381,12 @@ function SearchContent({ popularTags }: { popularTags?: PopularTag[] | null }) {
 }
 
 export function SearchPageClient({ popularTags }: SearchPageClientProps) {
-  const meilisearchHost = process.env.NEXT_PUBLIC_MEILISEARCH_HOST || 'http://localhost:7700'
-  const meilisearchKey = process.env.NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY || ''
+  const locale = useLocale() as ProviderLocale
 
-  // Dev-only console warning when the search key is missing, so the
-  // resilient client's silent "no results" empty state doesn't trap
-  // anyone debugging a fresh clone. Pre-checked the key in
-  // `.env.example`; this is defensive for local installs that copied
-  // an older example or stripped the value. (#160 / QA-112)
+  // Dev-only console warning when the Meilisearch search key is missing
+  // (the active default provider). Once Slice 2+ ships Algolia behind a
+  // flag this check moves into the provider itself. (#160 / QA-112)
+  const meilisearchKey = process.env.NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY || ''
   if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development' && !meilisearchKey) {
     // eslint-disable-next-line no-console
     console.warn(
@@ -396,36 +395,14 @@ export function SearchPageClient({ popularTags }: SearchPageClientProps) {
     )
   }
 
-  // Wrap Meilisearch client in a proxy that catches connection errors gracefully.
-  // Without this, a missing Meilisearch instance throws a noisy console error.
-  const { searchClient } = useMemo(() => {
-    const { searchClient: rawClient } = instantMeiliSearch(meilisearchHost, meilisearchKey)
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    const resilientClient = {
-      ...rawClient,
-      search: async (requests: any) => {
-        try {
-          return await (rawClient as any).search(requests)
-        } catch {
-          // Meilisearch unavailable — return empty results instead of throwing
-          return { results: (requests as Array<{ indexName: string }>).map((req) => ({
-            hits: [],
-            nbHits: 0,
-            page: 0,
-            nbPages: 0,
-            hitsPerPage: 20,
-            exhaustiveNbHits: true,
-            query: '',
-            params: '',
-            processingTimeMs: 0,
-            index: req.indexName,
-          })) }
-        }
-      },
-    }
-    /* eslint-enable @typescript-eslint/no-explicit-any */
-    return { searchClient: resilientClient }
-  }, [meilisearchHost, meilisearchKey])
+  // Provider-agnostic search client — `getSearchProvider()` reads the
+  // SEARCH_PROVIDER env var and dispatches to the right adapter
+  // (Meilisearch today; Algolia per #173+). The locale is forwarded for
+  // when FR indexes come online in Slice 3. (#172 / Algolia Slice 1)
+  const searchClient = useMemo(
+    () => getSearchProvider().getSearchClient(locale),
+    [locale],
+  )
 
   const searchParams = useSearchParams()
   const initialQuery = searchParams.get('q') || ''

--- a/src/collections/Consultations.ts
+++ b/src/collections/Consultations.ts
@@ -28,12 +28,12 @@
  */
 import type { CollectionConfig } from 'payload'
 
-import { syncToMeilisearch } from '@/search/meilisearch-sync'
+import { getSearchProvider } from '@/search'
 import { workflowFields } from '@/fields/workflow'
 import { contentRead, contentCreate, contentUpdate, contentDelete } from '@/access/roles'
 import { validateWorkflowTransition, createLogWorkflowTransition } from '@/admin/hooks/workflow-hooks'
 
-const { afterChange: meilisearchAfterChange, afterDelete } = syncToMeilisearch({ indexName: 'consultations' })
+const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'consultations' })
 
 export const Consultations: CollectionConfig = {
   slug: 'consultations',
@@ -57,7 +57,7 @@ export const Consultations: CollectionConfig = {
   },
   hooks: {
     beforeChange: [validateWorkflowTransition],
-    afterChange: [createLogWorkflowTransition('consultations'), meilisearchAfterChange],
+    afterChange: [createLogWorkflowTransition('consultations'), searchSyncAfterChange],
     afterDelete: [afterDelete],
   },
   fields: [

--- a/src/collections/Documents.ts
+++ b/src/collections/Documents.ts
@@ -27,13 +27,13 @@
  */
 import type { CollectionConfig } from 'payload'
 
-import { syncToMeilisearch } from '@/search/meilisearch-sync'
+import { getSearchProvider } from '@/search'
 import { extractDocumentText } from '@/search/document-extraction'
 import { workflowFields } from '@/fields/workflow'
 import { contentRead, contentCreate, contentUpdate, contentDelete } from '@/access/roles'
 import { validateWorkflowTransition, createLogWorkflowTransition } from '@/admin/hooks/workflow-hooks'
 
-const { afterChange: meilisearchAfterChange, afterDelete } = syncToMeilisearch({ indexName: 'documents' })
+const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'documents' })
 
 export const Documents: CollectionConfig = {
   slug: 'documents',
@@ -58,7 +58,7 @@ export const Documents: CollectionConfig = {
   },
   hooks: {
     beforeChange: [validateWorkflowTransition],
-    afterChange: [createLogWorkflowTransition('documents'), meilisearchAfterChange, extractDocumentText],
+    afterChange: [createLogWorkflowTransition('documents'), searchSyncAfterChange, extractDocumentText],
     afterDelete: [afterDelete],
   },
   fields: [

--- a/src/collections/Events.ts
+++ b/src/collections/Events.ts
@@ -27,12 +27,12 @@
  */
 import type { CollectionConfig } from 'payload'
 
-import { syncToMeilisearch } from '@/search/meilisearch-sync'
+import { getSearchProvider } from '@/search'
 import { workflowFields } from '@/fields/workflow'
 import { contentRead, contentCreate, contentUpdate, contentDelete } from '@/access/roles'
 import { validateWorkflowTransition, createLogWorkflowTransition } from '@/admin/hooks/workflow-hooks'
 
-const { afterChange: meilisearchAfterChange, afterDelete } = syncToMeilisearch({ indexName: 'events' })
+const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'events' })
 
 export const Events: CollectionConfig = {
   slug: 'events',
@@ -57,7 +57,7 @@ export const Events: CollectionConfig = {
   },
   hooks: {
     beforeChange: [validateWorkflowTransition],
-    afterChange: [createLogWorkflowTransition('events'), meilisearchAfterChange],
+    afterChange: [createLogWorkflowTransition('events'), searchSyncAfterChange],
     afterDelete: [afterDelete],
   },
   fields: [

--- a/src/collections/News.ts
+++ b/src/collections/News.ts
@@ -29,12 +29,12 @@
  */
 import type { CollectionConfig } from 'payload'
 
-import { syncToMeilisearch } from '@/search/meilisearch-sync'
+import { getSearchProvider } from '@/search'
 import { workflowFields } from '@/fields/workflow'
 import { contentRead, contentCreate, contentUpdate, contentDelete } from '@/access/roles'
 import { validateWorkflowTransition, createLogWorkflowTransition } from '@/admin/hooks/workflow-hooks'
 
-const { afterChange: meilisearchAfterChange, afterDelete } = syncToMeilisearch({ indexName: 'news' })
+const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'news' })
 
 export const News: CollectionConfig = {
   slug: 'news',
@@ -61,7 +61,7 @@ export const News: CollectionConfig = {
   },
   hooks: {
     beforeChange: [validateWorkflowTransition],
-    afterChange: [createLogWorkflowTransition('news'), meilisearchAfterChange],
+    afterChange: [createLogWorkflowTransition('news'), searchSyncAfterChange],
     afterDelete: [afterDelete],
   },
   fields: [

--- a/src/collections/Pages.ts
+++ b/src/collections/Pages.ts
@@ -45,14 +45,14 @@ import type { CollectionConfig } from 'payload'
 
 import { hero } from '@/heros/config'
 import { blocks } from '@/blocks'
-import { syncToMeilisearch } from '@/search/meilisearch-sync'
+import { getSearchProvider } from '@/search'
 import { workflowFields } from '@/fields/workflow'
 import { contentRead, contentCreate, contentUpdate, contentDelete } from '@/access/roles'
 import { validateWorkflowTransition, createLogWorkflowTransition } from '@/admin/hooks/workflow-hooks'
 import { clearExpiredLock } from '@/admin/hooks/locking-hooks'
 import { templateOptions } from '@/admin/templates'
 
-const { afterChange: meilisearchAfterChange, afterDelete } = syncToMeilisearch({ indexName: 'pages' })
+const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'pages' })
 
 export const Pages: CollectionConfig = {
   slug: 'pages',
@@ -82,7 +82,7 @@ export const Pages: CollectionConfig = {
   },
   hooks: {
     beforeChange: [clearExpiredLock, validateWorkflowTransition],
-    afterChange: [createLogWorkflowTransition('pages'), meilisearchAfterChange],
+    afterChange: [createLogWorkflowTransition('pages'), searchSyncAfterChange],
     afterDelete: [afterDelete],
   },
   fields: [

--- a/src/collections/Projects.ts
+++ b/src/collections/Projects.ts
@@ -29,12 +29,12 @@
  */
 import type { CollectionConfig } from 'payload'
 
-import { syncToMeilisearch } from '@/search/meilisearch-sync'
+import { getSearchProvider } from '@/search'
 import { workflowFields } from '@/fields/workflow'
 import { contentRead, contentCreate, contentUpdate, contentDelete } from '@/access/roles'
 import { validateWorkflowTransition, createLogWorkflowTransition } from '@/admin/hooks/workflow-hooks'
 
-const { afterChange: meilisearchAfterChange, afterDelete } = syncToMeilisearch({ indexName: 'projects' })
+const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'projects' })
 
 export const Projects: CollectionConfig = {
   slug: 'projects',
@@ -61,7 +61,7 @@ export const Projects: CollectionConfig = {
   },
   hooks: {
     beforeChange: [validateWorkflowTransition],
-    afterChange: [createLogWorkflowTransition('projects'), meilisearchAfterChange],
+    afterChange: [createLogWorkflowTransition('projects'), searchSyncAfterChange],
     afterDelete: [afterDelete],
   },
   fields: [

--- a/src/search/__tests__/provider-conformance.test.ts
+++ b/src/search/__tests__/provider-conformance.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @description
+ * Parameterized conformance tests for every `SearchProvider`
+ * implementation. Pins the interface contract so a new provider can't
+ * land without satisfying the same shape.
+ *
+ * Slice 1 (#172) registers only `meilisearchProvider`; the table below
+ * grows when Slice 2 (#173) lands the Algolia provider.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { meilisearchProvider } from '../meilisearch'
+import type { SearchProvider } from '../types'
+
+const PROVIDERS: Array<[string, SearchProvider]> = [
+  ['meilisearch', meilisearchProvider],
+]
+
+describe.each(PROVIDERS)('SearchProvider conformance — %s', (_name, provider) => {
+  it('exposes a stable string `name`', () => {
+    expect(typeof provider.name).toBe('string')
+    expect(provider.name.length).toBeGreaterThan(0)
+  })
+
+  it('returns sync hooks with `afterChange` and `afterDelete`', () => {
+    const hooks = provider.getSyncHooks({ indexName: 'unit-test-index' })
+    expect(typeof hooks.afterChange).toBe('function')
+    expect(typeof hooks.afterDelete).toBe('function')
+  })
+
+  it("each search client exposes a callable `.search`", () => {
+    const en = provider.getSearchClient('en')
+    const fr = provider.getSearchClient('fr')
+    expect(typeof en.search).toBe('function')
+    expect(typeof fr.search).toBe('function')
+  })
+
+  it('`applySettings` is awaitable and returns void', async () => {
+    // We don't have a live Meilisearch instance in unit tests; the
+    // provider's settings call is expected to no-op when the host is
+    // unreachable. This test pins the return contract, not the side
+    // effect — that's covered by integration tests at deploy time.
+    const result = await provider.applySettings('unit-test-index', {
+      filterableAttributes: ['board'],
+    })
+    expect(result).toBeUndefined()
+  })
+})

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -1,0 +1,58 @@
+/**
+ * @description
+ * `getSearchProvider()` — the only thing collection configs and frontend
+ * search clients should call. Reads `SEARCH_PROVIDER` from the env (default
+ * `meilisearch`) and returns the conforming `SearchProvider`.
+ *
+ * Adding a new provider:
+ * 1. Implement the `SearchProvider` interface from `./types.ts` in
+ *    `src/search/<provider>/provider.ts`.
+ * 2. Add a case below.
+ * 3. Document the env var contract in `.env.example`.
+ *
+ * The factory is intentionally side-effect-free at module load — provider
+ * construction happens on first call so test harnesses can stub the env.
+ *
+ * (#172 / Algolia migration Slice 1.)
+ */
+import { meilisearchProvider } from './meilisearch'
+import {
+  SEARCH_PROVIDER_ENV,
+  type SearchProvider,
+  type SearchProviderName,
+} from './types'
+
+/** Memoize per provider name so we don't rebuild the resilient client
+    on every render. */
+const cache = new Map<SearchProviderName, SearchProvider>()
+
+function resolveProviderName(): SearchProviderName {
+  const raw = process.env[SEARCH_PROVIDER_ENV]?.toLowerCase().trim()
+  if (raw === 'algolia') {
+    // Slice 2+ ships the Algolia adapter behind a flag; until then,
+    // explicitly opting in falls through to the default + a warning so
+    // a misconfigured env doesn't silently disable search.
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        `[search] SEARCH_PROVIDER=algolia is reserved (see #173). Falling back to 'meilisearch'.`,
+      )
+    }
+    return 'meilisearch'
+  }
+  return 'meilisearch'
+}
+
+export function getSearchProvider(): SearchProvider {
+  const name = resolveProviderName()
+  const cached = cache.get(name)
+  if (cached) return cached
+  // Currently `meilisearch` is the only registered provider; Slice 2+
+  // will add an `algolia` case below. The factory uses the env-driven
+  // name as the cache key so a future `SEARCH_PROVIDER=algolia` flip
+  // doesn't recompute Meili's resilient client.
+  const provider: SearchProvider = meilisearchProvider
+  cache.set(name, provider)
+  return provider
+}
+
+export type { SearchProvider, SyncHooks, SyncHooksConfig, IndexSettings, SearchClient } from './types'

--- a/src/search/meilisearch-client.ts
+++ b/src/search/meilisearch-client.ts
@@ -1,41 +1,10 @@
 /**
  * @description
- * Meilisearch client singleton for server-side operations.
- * Uses the meilisearch JS client directly (NOT payload-meilisearch plugin,
- * which only supports Payload 1.x).
+ * Backwards-compat shim — re-exports the canonical
+ * `getMeilisearchAdminClient` from `./meilisearch/client`.
  *
- * Key features:
- * - Singleton instance for reuse across hooks
- * - Configured from environment variables
- * - Admin API key for indexing operations
- *
- * @dependencies
- * - meilisearch: Official Meilisearch JS client
- *
- * @notes
- * - Server-side only — never import in client components
- * - Uses MEILISEARCH_HOST and MEILISEARCH_API_KEY from env
- * - Returns null if env vars are not configured (graceful degradation)
+ * Direct callers should import from `./meilisearch/client` or, for
+ * provider-agnostic code, go through `getSearchProvider()` from
+ * `@/search`. (#172 / Algolia migration Slice 1.)
  */
-import { MeiliSearch } from 'meilisearch'
-
-let client: MeiliSearch | null = null
-
-export function getMeilisearchClient(): MeiliSearch | null {
-  if (client) return client
-
-  const host = process.env.MEILISEARCH_HOST
-  const apiKey = process.env.MEILISEARCH_API_KEY
-
-  if (!host) {
-    console.warn('[Meilisearch] MEILISEARCH_HOST not configured — search sync disabled')
-    return null
-  }
-
-  client = new MeiliSearch({
-    host,
-    apiKey: apiKey || undefined,
-  })
-
-  return client
-}
+export { getMeilisearchAdminClient as getMeilisearchClient } from './meilisearch/client'

--- a/src/search/meilisearch-sync.ts
+++ b/src/search/meilisearch-sync.ts
@@ -1,152 +1,16 @@
 /**
  * @description
- * Meilisearch sync hooks for Payload CMS collections.
- * Provides afterChange and afterDelete hooks that sync documents
- * to Meilisearch indexes automatically.
+ * Backwards-compat shim. The canonical entry point is now
+ * `getSearchProvider().getSyncHooks(config)` from `@/search` —
+ * see #172 (Algolia migration Slice 1: provider abstraction).
  *
- * Key features:
- * - syncToMeilisearch() returns afterChange + afterDelete hooks
- * - Bilingual indexes: {collection}_en, {collection}_fr
- * - Configurable searchable and filterable attributes per collection
- * - Graceful error handling — sync failures don't block CMS saves
- *
- * @dependencies
- * - meilisearch-client: Singleton Meilisearch client
- *
- * @notes
- * - Custom hooks (NOT payload-meilisearch plugin — only supports Payload 1.x)
- * - Indexes are created on first document sync if they don't exist
- * - Filterable attributes: board, standard, content_type, file_type, date
- * - Searchable attributes: title, body, excerpt
- * - Document ID in Meilisearch = Payload document ID
+ * Kept so any legacy import path still resolves while the codebase
+ * migrates. Will be removed in a future cleanup once all imports point
+ * at `@/search` directly.
  */
-import type {
-  CollectionAfterChangeHook,
-  CollectionAfterDeleteHook,
-} from 'payload'
+import type { SyncHooksConfig } from './types'
+import { getSearchProvider } from './index'
 
-import { getMeilisearchClient } from './meilisearch-client'
-
-type SyncConfig = {
-  /** The Meilisearch index name (e.g., 'projects', 'news') */
-  indexName: string
-  /** Function to transform Payload doc into Meilisearch document */
-  transform?: (doc: Record<string, unknown>) => Record<string, unknown>
-}
-
-/** Default filterable attributes for all searchable collections */
-const DEFAULT_FILTERABLE_ATTRIBUTES = [
-  'board',
-  'standard',
-  'content_type',
-  'file_type',
-  'date',
-  'status',
-]
-
-/** Default searchable attributes */
-const DEFAULT_SEARCHABLE_ATTRIBUTES = [
-  'title',
-  'body',
-  'excerpt',
-  'summary',
-]
-
-/**
- * Default transform — extracts common fields from a Payload document
- * into a flat Meilisearch document.
- */
-function defaultTransform(doc: Record<string, unknown>): Record<string, unknown> {
-  const board = doc.board as Record<string, unknown> | string | undefined
-  const boardAbbreviation = typeof board === 'object' && board ? board.abbreviation : board
-
-  return {
-    id: doc.id,
-    title: doc.title || '',
-    slug: doc.slug || '',
-    summary: doc.summary || doc.excerpt || '',
-    body: doc.content || doc.body || '',
-    board: boardAbbreviation || '',
-    status: doc.status || '',
-    date: doc.publishedDate || doc.date || doc.createdAt || '',
-    content_type: doc.type || '',
-    updatedAt: doc.updatedAt || '',
-  }
-}
-
-/**
- * Configures Meilisearch index settings (filterable, searchable attributes).
- * Called once per index on first sync.
- */
-async function ensureIndexSettings(indexName: string): Promise<void> {
-  const client = getMeilisearchClient()
-  if (!client) return
-
-  try {
-    // Create index if it doesn't exist (no-op if exists)
-    await client.createIndex(indexName, { primaryKey: 'id' })
-
-    // Configure filterable and searchable attributes
-    const index = client.index(indexName)
-    await index.updateFilterableAttributes(DEFAULT_FILTERABLE_ATTRIBUTES)
-    await index.updateSearchableAttributes(DEFAULT_SEARCHABLE_ATTRIBUTES)
-  } catch (error) {
-    // Index may already exist with settings — that's fine
-    console.warn(`[Meilisearch] Index setup for '${indexName}':`, error)
-  }
-}
-
-// Track which indexes have been configured
-const configuredIndexes = new Set<string>()
-
-/**
- * Creates afterChange and afterDelete hooks for syncing a Payload collection
- * to Meilisearch. Register these hooks on searchable collections.
- *
- * Usage:
- *   const { afterChange, afterDelete } = syncToMeilisearch({ indexName: 'news' })
- *   // Add to collection config: hooks: { afterChange: [afterChange], afterDelete: [afterDelete] }
- */
-export function syncToMeilisearch(config: SyncConfig) {
-  const { indexName, transform = defaultTransform } = config
-
-  // For bilingual support, we use {indexName}_en
-  // FR index support will be added when i18n is implemented (Epic 18)
-  const enIndexName = `${indexName}_en`
-
-  const afterChange: CollectionAfterChangeHook = async ({ doc }) => {
-    const client = getMeilisearchClient()
-    if (!client) return doc
-
-    try {
-      // Ensure index is configured on first sync
-      if (!configuredIndexes.has(enIndexName)) {
-        await ensureIndexSettings(enIndexName)
-        configuredIndexes.add(enIndexName)
-      }
-
-      const meilisearchDoc = transform(doc as Record<string, unknown>)
-      const index = client.index(enIndexName)
-      await index.addDocuments([meilisearchDoc])
-    } catch (error) {
-      // Don't block CMS save on sync failure
-      console.error(`[Meilisearch] Failed to sync document to '${enIndexName}':`, error)
-    }
-
-    return doc
-  }
-
-  const afterDelete: CollectionAfterDeleteHook = async ({ doc }) => {
-    const client = getMeilisearchClient()
-    if (!client || !doc) return
-
-    try {
-      const index = client.index(enIndexName)
-      await index.deleteDocument(String(doc.id))
-    } catch (error) {
-      console.error(`[Meilisearch] Failed to delete document from '${enIndexName}':`, error)
-    }
-  }
-
-  return { afterChange, afterDelete }
+export function syncToMeilisearch(config: SyncHooksConfig) {
+  return getSearchProvider().getSyncHooks(config)
 }

--- a/src/search/meilisearch/client.ts
+++ b/src/search/meilisearch/client.ts
@@ -1,0 +1,36 @@
+/**
+ * @description
+ * Meilisearch server client singleton (admin key — full read/write).
+ * Used by sync hooks + `applySettings` for index management.
+ *
+ * Moved from `src/search/meilisearch-client.ts` as part of the
+ * `SearchProvider` abstraction (#172 / Algolia migration Slice 1).
+ *
+ * @notes
+ * - Server-side only — never import in client components.
+ * - `getSearchClient(locale)` for the frontend builds an InstantSearch
+ *   client with the search-only key (see `./provider.ts`).
+ * - Returns null if `MEILISEARCH_HOST` is unset (graceful degradation).
+ */
+import { MeiliSearch } from 'meilisearch'
+
+let client: MeiliSearch | null = null
+
+export function getMeilisearchAdminClient(): MeiliSearch | null {
+  if (client) return client
+
+  const host = process.env.MEILISEARCH_HOST
+  const apiKey = process.env.MEILISEARCH_API_KEY
+
+  if (!host) {
+    console.warn('[Meilisearch] MEILISEARCH_HOST not configured — search sync disabled')
+    return null
+  }
+
+  client = new MeiliSearch({
+    host,
+    apiKey: apiKey || undefined,
+  })
+
+  return client
+}

--- a/src/search/meilisearch/index.ts
+++ b/src/search/meilisearch/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @description
+ * Public exports for the Meilisearch provider implementation.
+ * The factory at `src/search/index.ts` is the only thing that should
+ * import from this module — collection configs go through
+ * `getSearchProvider()` and call `getSyncHooks(...)` on the result.
+ *
+ * (#172 / Algolia migration Slice 1 — provider abstraction.)
+ */
+export { meilisearchProvider } from './provider'

--- a/src/search/meilisearch/provider.ts
+++ b/src/search/meilisearch/provider.ts
@@ -1,0 +1,75 @@
+/**
+ * @description
+ * `MeilisearchProvider` — the default `SearchProvider` implementation,
+ * conforming to `src/search/types.ts`. Wraps the Meilisearch client +
+ * sync helpers + InstantSearch frontend connector.
+ *
+ * Introduced in #172 / Algolia migration Slice 1 as part of the
+ * provider-agnostic abstraction. No behavior change vs the pre-refactor
+ * code — `SEARCH_PROVIDER=meilisearch` (or unset) is the default.
+ */
+import { instantMeiliSearch } from '@meilisearch/instant-meilisearch'
+
+import type {
+  IndexSettings,
+  ProviderLocale,
+  SearchClient,
+  SearchProvider,
+  SyncHooks,
+  SyncHooksConfig,
+} from '../types'
+import { applyMeilisearchSettings, buildMeilisearchSyncHooks } from './sync'
+
+/** Lazily build a resilient InstantSearch client wrapping Meilisearch.
+    The wrapper swallows network errors so a Meilisearch outage renders
+    "0 results" instead of throwing in the React tree. */
+function buildResilientClient(host: string, key: string): SearchClient {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const { searchClient: rawClient } = instantMeiliSearch(host, key)
+  return {
+    ...rawClient,
+    search: async (requests: any) => {
+      try {
+        return await (rawClient as any).search(requests)
+      } catch {
+        return {
+          results: (requests as Array<{ indexName: string }>).map((req) => ({
+            hits: [],
+            nbHits: 0,
+            page: 0,
+            nbPages: 0,
+            hitsPerPage: 20,
+            exhaustiveNbHits: true,
+            query: '',
+            params: '',
+            processingTimeMs: 0,
+            index: req.indexName,
+          })),
+        }
+      }
+    },
+  } as unknown as SearchClient
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+}
+
+export const meilisearchProvider: SearchProvider = {
+  name: 'meilisearch',
+
+  getSyncHooks(config: SyncHooksConfig): SyncHooks {
+    return buildMeilisearchSyncHooks(config)
+  },
+
+  getSearchClient(_locale: ProviderLocale): SearchClient {
+    // FR-locale support comes online with Slice 3 — for now both locales
+    // hit the same `_en` indexes; the locale param is accepted so the
+    // signature matches the future Algolia provider one-for-one.
+    void _locale
+    const host = process.env.NEXT_PUBLIC_MEILISEARCH_HOST || 'http://localhost:7700'
+    const key = process.env.NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY || ''
+    return buildResilientClient(host, key)
+  },
+
+  async applySettings(indexName: string, settings: IndexSettings): Promise<void> {
+    await applyMeilisearchSettings(indexName, settings)
+  },
+}

--- a/src/search/meilisearch/sync.ts
+++ b/src/search/meilisearch/sync.ts
@@ -1,0 +1,137 @@
+/**
+ * @description
+ * Meilisearch sync — Payload `afterChange` + `afterDelete` hooks that
+ * mirror Payload documents into Meilisearch indexes.
+ *
+ * Moved from `src/search/meilisearch-sync.ts` as part of the
+ * `SearchProvider` abstraction (#172 / Algolia migration Slice 1). The
+ * public surface is now `meilisearchProvider.getSyncHooks(config)` —
+ * collection configs no longer import this module directly.
+ *
+ * @notes
+ * - Bilingual indexes: `{collection}_en` (FR comes online with Slice 3).
+ * - Filterable: board / standard / content_type / file_type / date / status.
+ * - Searchable: title / body / excerpt / summary.
+ * - Failures are swallowed so a Meilisearch outage doesn't block CMS saves.
+ */
+import type {
+  CollectionAfterChangeHook,
+  CollectionAfterDeleteHook,
+} from 'payload'
+
+import type { IndexSettings, SyncHooks, SyncHooksConfig } from '../types'
+import { getMeilisearchAdminClient } from './client'
+
+/** Default filterable attributes for all searchable collections */
+const DEFAULT_FILTERABLE_ATTRIBUTES = [
+  'board',
+  'standard',
+  'content_type',
+  'file_type',
+  'date',
+  'status',
+]
+
+/** Default searchable attributes */
+const DEFAULT_SEARCHABLE_ATTRIBUTES = [
+  'title',
+  'body',
+  'excerpt',
+  'summary',
+]
+
+/** Default transform — extracts common fields from a Payload document
+    into a flat Meilisearch document. */
+function defaultTransform(doc: Record<string, unknown>): Record<string, unknown> {
+  const board = doc.board as Record<string, unknown> | string | undefined
+  const boardAbbreviation = typeof board === 'object' && board ? board.abbreviation : board
+
+  return {
+    id: doc.id,
+    title: doc.title || '',
+    slug: doc.slug || '',
+    summary: doc.summary || doc.excerpt || '',
+    body: doc.content || doc.body || '',
+    board: boardAbbreviation || '',
+    status: doc.status || '',
+    date: doc.publishedDate || doc.date || doc.createdAt || '',
+    content_type: doc.type || '',
+    updatedAt: doc.updatedAt || '',
+  }
+}
+
+/** Track which Meilisearch indexes have already had settings pushed
+    so we don't re-issue the same settings call on every sync. */
+const configuredIndexes = new Set<string>()
+
+/** Push searchable + filterable settings to a Meilisearch index. Used by
+    both the auto-configure path (first sync) and the
+    `MeilisearchProvider.applySettings` API. */
+export async function applyMeilisearchSettings(
+  indexName: string,
+  settings: IndexSettings = {},
+): Promise<void> {
+  const client = getMeilisearchAdminClient()
+  if (!client) return
+
+  const filterable = settings.filterableAttributes ?? DEFAULT_FILTERABLE_ATTRIBUTES
+  const searchable = settings.searchableAttributes ?? DEFAULT_SEARCHABLE_ATTRIBUTES
+
+  try {
+    await client.createIndex(indexName, { primaryKey: 'id' })
+    const index = client.index(indexName)
+    await index.updateFilterableAttributes(filterable)
+    await index.updateSearchableAttributes(searchable)
+    if (settings.sortableAttributes) {
+      await index.updateSortableAttributes(settings.sortableAttributes)
+    }
+  } catch (error) {
+    console.warn(`[Meilisearch] Index setup for '${indexName}':`, error)
+  }
+}
+
+/**
+ * Build Meilisearch sync hooks for a Payload collection.
+ *
+ * Exposed via `MeilisearchProvider.getSyncHooks(config)`; not normally
+ * imported directly.
+ */
+export function buildMeilisearchSyncHooks(config: SyncHooksConfig): SyncHooks {
+  const { indexName, transform = defaultTransform } = config
+  // Bilingual indexes — FR comes online with Slice 3.
+  const enIndexName = `${indexName}_en`
+
+  const afterChange: CollectionAfterChangeHook = async ({ doc }) => {
+    const client = getMeilisearchAdminClient()
+    if (!client) return doc
+
+    try {
+      if (!configuredIndexes.has(enIndexName)) {
+        await applyMeilisearchSettings(enIndexName)
+        configuredIndexes.add(enIndexName)
+      }
+
+      const meilisearchDoc = transform(doc as Record<string, unknown>)
+      const index = client.index(enIndexName)
+      await index.addDocuments([meilisearchDoc])
+    } catch (error) {
+      console.error(`[Meilisearch] Failed to sync document to '${enIndexName}':`, error)
+    }
+
+    return doc
+  }
+
+  const afterDelete: CollectionAfterDeleteHook = async ({ doc }) => {
+    const client = getMeilisearchAdminClient()
+    if (!client || !doc) return
+
+    try {
+      const index = client.index(enIndexName)
+      await index.deleteDocument(String(doc.id))
+    } catch (error) {
+      console.error(`[Meilisearch] Failed to delete document from '${enIndexName}':`, error)
+    }
+  }
+
+  return { afterChange, afterDelete }
+}

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -1,0 +1,83 @@
+/**
+ * @description
+ * Provider-agnostic search interface for FRAS Canada.
+ *
+ * Two implementations live behind this:
+ * - `MeilisearchProvider` (default, current production) — `src/search/meilisearch/`
+ * - `AlgoliaProvider` (in-progress per #171) — `src/search/algolia/`
+ *
+ * The `getSearchProvider()` factory in `./index.ts` reads `SEARCH_PROVIDER`
+ * env var and dispatches to the right one. Code that synchronizes
+ * Payload collections or hydrates a search client should depend on this
+ * interface — never on a specific provider's exports.
+ *
+ * @notes
+ * - Server-only: this file is imported from Payload collection configs
+ *   (`afterChange` / `afterDelete` hooks) and from frontend client
+ *   components (`getSearchClient` only). The factory checks the env at
+ *   call time so flipping `SEARCH_PROVIDER` requires only a server
+ *   restart, not a rebuild.
+ */
+import type {
+  CollectionAfterChangeHook,
+  CollectionAfterDeleteHook,
+} from 'payload'
+
+/** Configuration handed to `getSyncHooks`. */
+export type SyncHooksConfig = {
+  /** Logical index name (e.g. 'news', 'projects'). The provider may
+      append a locale suffix internally (Meilisearch: `news_en`). */
+  indexName: string
+  /** Optional transform from a populated Payload doc to the search
+      record. Falls back to a provider-specific default. */
+  transform?: (doc: Record<string, unknown>) => Record<string, unknown>
+}
+
+/** What every provider must return for sync. */
+export type SyncHooks = {
+  afterChange: CollectionAfterChangeHook
+  afterDelete: CollectionAfterDeleteHook
+}
+
+/** Index-settings shape — small per-provider supersets. Both providers
+    accept this minimal shape and ignore unknown fields. */
+export type IndexSettings = {
+  searchableAttributes?: string[]
+  filterableAttributes?: string[]
+  sortableAttributes?: string[]
+}
+
+/** Minimal Algoliasearch-compatible client shape that
+    `react-instantsearch` accepts. Both Meilisearch (via
+    `@meilisearch/instant-meilisearch`) and Algolia (via `algoliasearch`)
+    return this same shape. */
+export type SearchClient = {
+  search: (requests: unknown) => Promise<unknown>
+  // Provider-specific extensions are allowed as additional properties.
+  [key: string]: unknown
+}
+
+/** Provider locale tag — kept narrow to match Payload's locale codes. */
+export type ProviderLocale = 'en' | 'fr'
+
+/** The interface every search provider conforms to. */
+export interface SearchProvider {
+  /** Stable identifier for logs / metrics — e.g. 'meilisearch', 'algolia'. */
+  readonly name: 'meilisearch' | 'algolia'
+
+  /** Build Payload `afterChange` + `afterDelete` hooks for a collection. */
+  getSyncHooks(config: SyncHooksConfig): SyncHooks
+
+  /** Return an InstantSearch-compatible client for the frontend. */
+  getSearchClient(locale: ProviderLocale): SearchClient
+
+  /** Push index settings (searchable / filterable / sortable). Idempotent
+      — providers should treat this as "ensure these settings". */
+  applySettings(indexName: string, settings: IndexSettings): Promise<void>
+}
+
+/** Env-var key that selects the provider. Default: `meilisearch`. */
+export const SEARCH_PROVIDER_ENV = 'SEARCH_PROVIDER'
+
+/** Allowed values for `SEARCH_PROVIDER`. */
+export type SearchProviderName = SearchProvider['name']


### PR DESCRIPTION
## Summary

Pure refactor. `SEARCH_PROVIDER` unset (or `meilisearch`) keeps the same behavior as `main`. Lays the foundation for the Algolia adapter (Slice 2, #173).

## What changed

- `src/search/types.ts` — `SearchProvider` interface (`getSyncHooks`, `getSearchClient`, `applySettings`)
- `src/search/meilisearch/` — refactored Meilisearch implementation
- `src/search/index.ts` — `getSearchProvider()` factory + env-var dispatch
- 6 collections + `SearchPageClient` migrated to the factory
- `src/search/__tests__/provider-conformance.test.ts` — parameterized contract test
- Legacy paths kept as thin shims for backwards compat

## Verification

- `tsc --noEmit` clean
- `npx vitest run` 337/337 (was 333 — +4 conformance cases)
- Live `/en/search?q=crypto` + `/en/acsb` 200 OK

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)