### PR TITLE
feat(search): Algolia adapter for News — code complete (Slice 2, #173)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,13 @@ PREVIEW_SECRET=CHANGE_ME_GENERATE_WITH_openssl_rand_hex_32
 # Build timestamp shown on /cms; set by your deploy pipeline.
 NEXT_PUBLIC_BUILD_TIME=
 
+# ── Search provider selector (#172 / Algolia migration) ─────────────────
+# Selects which SearchProvider backs sync hooks + frontend search.
+# Values: `meilisearch` (default) | `algolia`
+# Leave unset for the default. Flip to `algolia` to opt into the Slice 2
+# adapter — requires the ALGOLIA_* keys below to be populated.
+SEARCH_PROVIDER=
+
 # ── Meilisearch ─────────────────────────────────────────────────────────
 # Self-hosted Docker instance (see docker-compose.yml)
 MEILISEARCH_HOST=http://localhost:7700
@@ -35,6 +42,18 @@ NEXT_PUBLIC_MEILISEARCH_HOST=http://localhost:7700
 # (no write access), safe to expose to the browser. For prod, use a unique
 # master key + a generated search-only key.
 NEXT_PUBLIC_MEILISEARCH_SEARCH_KEY=21064765ec8c9473984a45ea602d1635d425c9dbce2690839bc281c2c7e5aff1
+
+# ── Algolia (#173 / Algolia migration Slice 2) ──────────────────────────
+# Get keys from https://dashboard.algolia.com/account/api-keys
+# Server-side admin key — full read/write to all indexes. NEVER expose
+# this to the browser. Used by sync hooks + apply-settings + backfill.
+ALGOLIA_APP_ID=
+ALGOLIA_ADMIN_API_KEY=
+# Frontend-safe search-only key. Restrict to the `news_*` indexes (and
+# whatever Slice 3 expansion adds) via the Algolia dashboard. Browser
+# bundles include this; never use the admin key here.
+NEXT_PUBLIC_ALGOLIA_APP_ID=
+NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY=
 
 # ── Clerk (Auth) ──────────────────────────────────────────────────────────
 # Clerk handles frontend auth (login, signup, session management).

--- a/infrastructure/algolia/settings.ts
+++ b/infrastructure/algolia/settings.ts
@@ -1,0 +1,40 @@
+/**
+ * @description
+ * Algolia index-settings-as-code. Source of truth for every Algolia
+ * index FRAS uses. The CI pipeline calls `apply-algolia-settings.mjs`
+ * on merges to main; the script reads this object and pushes settings
+ * to Algolia.
+ *
+ * Slice 2 (#173) seeds `news` only. Slice 3 (#174) adds the remaining
+ * collections. Slice 4 (#175) tightens the search-only key against the
+ * indexes listed here.
+ *
+ * @notes
+ * - Per-locale indexes — `news_en`, `news_fr`. Per-language tokenization
+ *   driven by Algolia's `indexLanguages` once Slice 3's expansion lands.
+ * - `attributesForFaceting` enables `filterOnly()` syntax for filters
+ *   the UI doesn't render as facet counts (board / status etc.).
+ */
+import type { IndexSettings } from '@/search/types'
+
+export type AlgoliaCollectionSettings = {
+  /** Logical Payload collection slug — used to derive `<slug>_en` /
+      `<slug>_fr` index names. */
+  collection: string
+  /** Settings applied identically to both locale-specific indexes. */
+  settings: IndexSettings
+}
+
+export const ALGOLIA_INDEX_SETTINGS: readonly AlgoliaCollectionSettings[] = [
+  {
+    collection: 'news',
+    settings: {
+      // Ranked by attribute order — title first, summary, then body.
+      searchableAttributes: ['title', 'summary', 'excerpt', 'body'],
+      // Faceted filters surfaced in `FilterSidebar`.
+      filterableAttributes: ['board', 'standard', 'content_type', 'date', 'status'],
+      // Sort dropdown surfaces these.
+      sortableAttributes: ['date', 'updatedAt'],
+    },
+  },
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@payloadcms/ui": "^3.84.1",
         "@tanstack/react-query": "^5.100.5",
         "@tanstack/react-query-devtools": "^5.100.5",
+        "algoliasearch": "^5.52.0",
         "cmdk": "^1.1.1",
         "dotenv": "^16.4.7",
         "graphql": "^16.10.0",
@@ -78,11 +79,206 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.18.0.tgz",
+      "integrity": "sha512-8siuLG+FIns1AjZ/g2SDVwHz9S+ObacDQISEJvS8XsNei1zl3FXqfqQrBpmrG7ACWCyesXHbicMJtvRbg00FEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.52.0.tgz",
+      "integrity": "sha512-wtwPgyPmO7b7sQPVgoK29c1VpfS08DnnJCmxX/oU1pV2DlMRJCzQcLN7JSloYpodyKHwM8+9wOzlAM0co3TDmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.52.0.tgz",
+      "integrity": "sha512-9KY36bRl4AH7RjqSeDDOKnjsz4IxQFBEOB8/fWmEbdQe+Isbs5jGzVJu9NEPQ1Tgwxlf8Uf07Swj3jZyMNUZ2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.52.0.tgz",
+      "integrity": "sha512-3a/qM3dzJqqfTx7Yrw7uGQ98I3Q0rDfb4Vkv0wEzko96l7YQMxfBVz/VbLq2N+c59GweYv6Vhp8mPeqnWJSITw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.52.0.tgz",
+      "integrity": "sha512-Rki7ACbMcvbQW0BuM84x9dkGHY47ABmv4jU6tYssat2k02p3mIUms2YOLUAMeknhmnFsj6lb6ZzOXdMWMyc1sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.52.0.tgz",
+      "integrity": "sha512-96s4Uzc3kk+/f4jJXIVVGWP5XlngOGNQ1x6hW9AT59pOixHlOs5tqJg+ZUS/GQ6h/iYP0ceQcmxDQeLyCLTaDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.52.0.tgz",
+      "integrity": "sha512-lqeycNpSPe5Qa0OUWpejVvYQjQWV5nQuLT0a4aq7XzRAvCxprV/6Lf841EygdD2nrFnuS58ok7Au1uOtXzpnkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.0.tgz",
+      "integrity": "sha512-ly1wETVGRo30cx61O7fetESN+ElL9c9K+bD/AVgnT1ar4c6v+/Yqjrhdtu6Fm4D0s4NZP081Isf6tunH1wUXHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/@algolia/events": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@algolia/events/-/events-4.0.1.tgz",
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==",
       "license": "MIT"
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.52.0.tgz",
+      "integrity": "sha512-U4EeTvgmluRjj39ykZSAd5X+a6LD5m7/mcOWDmB7hqm1R6QY0yT8jLxpNVEjYhzgEN5hcDGW6X67EWQY8KiYGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.52.0.tgz",
+      "integrity": "sha512-FCPnDcILfpTE94u7BVlV4DmnSV5wE3+j25EEF+3dYPrVzkVCSoAHs318oWDGxnxsAgiL4HpL12Jc4XHmw9shpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.52.0.tgz",
+      "integrity": "sha512-br3DO7n4N8CXwTRbZS0MnB4WQ9YHfNjCwkCEzVR/wek/qNTDQKDb0nROmkFaNZ8ucUqUVKZi074dbwMwRDlK8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.52.0.tgz",
+      "integrity": "sha512-b0T/Ca2c9KyEslKsVrGZvbe1UrrKKSdfXhBZ2pbpKahFUzJfziRZ0urbOm7V65O0tO/jwU+Lo/+bIiiyhzGt8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.52.0.tgz",
+      "integrity": "sha512-ozBT8J/mtD4H4IAojw8QPirlcL2gHrI1BGuZ4/ZXXO/rTE1yQ4VIPJj4mTTbwo4FbkS1MoJsD/DsrqLzhnc4/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.52.0.tgz",
+      "integrity": "sha512-gyyWcLD22tnabmoit4iukCXuoRc5HYJuUjPSEa8a0D/f/NlRafpWi52AlAaa4Uu/rsl7saHsJFTNjTptWbu2+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -7853,6 +8049,31 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.0.tgz",
+      "integrity": "sha512-0ZzY9mjqV7gop/AH8pIBiAS8giXP7WcSiUfoFYIzYAK9QC5c37E4SIVtJVBMwlURc0/uNt2o4RcNRvdHa4CJ5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.18.0",
+        "@algolia/client-abtesting": "5.52.0",
+        "@algolia/client-analytics": "5.52.0",
+        "@algolia/client-common": "5.52.0",
+        "@algolia/client-insights": "5.52.0",
+        "@algolia/client-personalization": "5.52.0",
+        "@algolia/client-query-suggestions": "5.52.0",
+        "@algolia/client-search": "5.52.0",
+        "@algolia/ingestion": "1.52.0",
+        "@algolia/monitoring": "1.52.0",
+        "@algolia/recommend": "5.52.0",
+        "@algolia/requester-browser-xhr": "5.52.0",
+        "@algolia/requester-fetch": "5.52.0",
+        "@algolia/requester-node-http": "5.52.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/algoliasearch-helper": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@payloadcms/ui": "^3.84.1",
     "@tanstack/react-query": "^5.100.5",
     "@tanstack/react-query-devtools": "^5.100.5",
+    "algoliasearch": "^5.52.0",
     "cmdk": "^1.1.1",
     "dotenv": "^16.4.7",
     "graphql": "^16.10.0",

--- a/scripts/algolia-backfill.mjs
+++ b/scripts/algolia-backfill.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * One-shot Algolia backfill for the News collection (Slice 2 POC).
+ *
+ * Usage:
+ *   node scripts/algolia-backfill.mjs                  # all news, both locales
+ *   node scripts/algolia-backfill.mjs --locale=fr      # FR only
+ *   node scripts/algolia-backfill.mjs --collections=news,projects   # multi
+ *
+ * Idempotent: re-running produces the same Algolia state — `objectID`
+ * is the Payload doc id, so saveObjects upserts in place.
+ *
+ * Reads the EXACT same env vars that the runtime sync uses
+ * (`ALGOLIA_APP_ID`, `ALGOLIA_ADMIN_API_KEY`); no separate config.
+ *
+ * (#173 / Algolia migration Slice 2.)
+ */
+import { algoliasearch } from 'algoliasearch'
+import { getPayload } from 'payload'
+
+const argv = Object.fromEntries(
+  process.argv.slice(2).map((arg) => {
+    if (!arg.startsWith('--')) return [arg, true]
+    const [key, ...rest] = arg.slice(2).split('=')
+    return [key, rest.length ? rest.join('=') : true]
+  }),
+)
+
+const COLLECTIONS = (argv.collections ? String(argv.collections).split(',') : ['news']).map((s) =>
+  s.trim(),
+)
+const LOCALES = argv.locale ? [String(argv.locale)] : ['en', 'fr']
+
+function transform(doc) {
+  const board = doc.board && typeof doc.board === 'object' ? doc.board : null
+  const boardAbbreviation = board ? board.abbreviation : doc.board
+  return {
+    objectID: String(doc.id),
+    title: doc.title || '',
+    slug: doc.slug || '',
+    summary: doc.summary || doc.excerpt || '',
+    body: doc.content || doc.body || '',
+    board: boardAbbreviation || '',
+    status: doc.status || '',
+    date: doc.publishedDate || doc.date || doc.createdAt || '',
+    content_type: doc.type || '',
+    updatedAt: doc.updatedAt || '',
+  }
+}
+
+async function main() {
+  const appId = process.env.ALGOLIA_APP_ID
+  const adminKey = process.env.ALGOLIA_ADMIN_API_KEY
+  if (!appId || !adminKey) {
+    console.error('[algolia-backfill] ALGOLIA_APP_ID / ALGOLIA_ADMIN_API_KEY missing — aborting.')
+    process.exit(1)
+  }
+
+  const algolia = algoliasearch(appId, adminKey)
+
+  const payloadConfig = (await import('../src/payload.config.ts')).default
+  const payload = await getPayload({ config: await payloadConfig })
+
+  let total = 0
+  for (const collection of COLLECTIONS) {
+    for (const locale of LOCALES) {
+      const indexName = `${collection}_${locale}`
+      console.log(`[algolia-backfill] → ${indexName}`)
+
+      const all = await payload.find({
+        collection,
+        limit: 5000,
+        depth: 3,
+        locale,
+        overrideAccess: true,
+        pagination: false,
+      })
+
+      const records = all.docs
+        .filter((doc) => doc.title || doc.slug)
+        .map((doc) => transform(doc))
+
+      if (records.length === 0) {
+        console.log(`  (skipped — 0 docs with content for ${locale})`)
+        continue
+      }
+
+      await algolia.saveObjects({ indexName, objects: records })
+      console.log(`  ✓ ${records.length} records pushed`)
+      total += records.length
+    }
+  }
+
+  console.log(`[algolia-backfill] done — ${total} record(s) total.`)
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error('[algolia-backfill] fatal:', err)
+  process.exit(1)
+})

--- a/scripts/apply-algolia-settings.mjs
+++ b/scripts/apply-algolia-settings.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Push the settings-as-code from `infrastructure/algolia/settings.ts`
+ * to Algolia. Called from CI on merge to main.
+ *
+ * Idempotent: Algolia merges partial settings server-side, so re-running
+ * is safe.
+ *
+ * Usage:
+ *   node scripts/apply-algolia-settings.mjs                # all collections
+ *   node scripts/apply-algolia-settings.mjs --collection=news
+ *
+ * (#173 / Algolia migration Slice 2.)
+ */
+import { algoliasearch } from 'algoliasearch'
+
+const argv = Object.fromEntries(
+  process.argv.slice(2).map((arg) => {
+    if (!arg.startsWith('--')) return [arg, true]
+    const [key, ...rest] = arg.slice(2).split('=')
+    return [key, rest.length ? rest.join('=') : true]
+  }),
+)
+
+const LOCALES = ['en', 'fr']
+
+async function main() {
+  const appId = process.env.ALGOLIA_APP_ID
+  const adminKey = process.env.ALGOLIA_ADMIN_API_KEY
+  if (!appId || !adminKey) {
+    console.error('[apply-algolia-settings] ALGOLIA_APP_ID / ALGOLIA_ADMIN_API_KEY missing — aborting.')
+    process.exit(1)
+  }
+
+  const algolia = algoliasearch(appId, adminKey)
+
+  // Dynamic import so the script can be called from a plain Node runner
+  // without a TS compile step (CI uses `tsx` to run this — see workflow).
+  const settings = (await import('../infrastructure/algolia/settings.ts')).ALGOLIA_INDEX_SETTINGS
+
+  const filter = argv.collection
+  const targets = filter
+    ? settings.filter((entry) => entry.collection === filter)
+    : settings
+
+  if (targets.length === 0) {
+    console.error(`[apply-algolia-settings] no settings entry for --collection=${filter}`)
+    process.exit(1)
+  }
+
+  for (const { collection, settings: indexSettings } of targets) {
+    for (const locale of LOCALES) {
+      const indexName = `${collection}_${locale}`
+      const algoliaSettings = {
+        searchableAttributes: indexSettings.searchableAttributes,
+        attributesForFaceting: indexSettings.filterableAttributes,
+        ...(indexSettings.sortableAttributes
+          ? { customRanking: indexSettings.sortableAttributes.map((a) => `desc(${a})`) }
+          : {}),
+      }
+      await algolia.setSettings({ indexName, indexSettings: algoliaSettings })
+      console.log(`  ✓ pushed settings to ${indexName}`)
+    }
+  }
+
+  console.log('[apply-algolia-settings] done.')
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error('[apply-algolia-settings] fatal:', err)
+  process.exit(1)
+})

--- a/src/search/__tests__/provider-conformance.test.ts
+++ b/src/search/__tests__/provider-conformance.test.ts
@@ -9,11 +9,13 @@
  */
 import { describe, expect, it } from 'vitest'
 
+import { algoliaProvider } from '../algolia'
 import { meilisearchProvider } from '../meilisearch'
 import type { SearchProvider } from '../types'
 
 const PROVIDERS: Array<[string, SearchProvider]> = [
   ['meilisearch', meilisearchProvider],
+  ['algolia', algoliaProvider],
 ]
 
 describe.each(PROVIDERS)('SearchProvider conformance — %s', (_name, provider) => {

--- a/src/search/algolia/client.ts
+++ b/src/search/algolia/client.ts
@@ -1,0 +1,51 @@
+/**
+ * @description
+ * Algolia server client singleton (admin API key — full read/write).
+ * Used by sync hooks + `applySettings` for index management.
+ *
+ * Lazy: never reads the env or constructs the client until first call,
+ * so importing this module is side-effect-free and safe to bundle in
+ * environments where Algolia credentials may not be set yet (CI without
+ * secrets, dev without account, etc.). Returns null in that case so
+ * callers can no-op gracefully — the same shape `getMeilisearchAdminClient`
+ * uses.
+ *
+ * (#173 / Algolia migration Slice 2 — News POC.)
+ *
+ * @notes
+ * - Server-side only — never import in client components.
+ * - The frontend gets a search-only client via the provider's
+ *   `getSearchClient(locale)` (different key, public-safe).
+ */
+import { algoliasearch, type Algoliasearch } from 'algoliasearch'
+
+let client: Algoliasearch | null = null
+let triedInit = false
+
+export function getAlgoliaAdminClient(): Algoliasearch | null {
+  if (client) return client
+  if (triedInit) return null
+  triedInit = true
+
+  const appId = process.env.ALGOLIA_APP_ID
+  const adminKey = process.env.ALGOLIA_ADMIN_API_KEY
+
+  if (!appId || !adminKey) {
+    if (process.env.NODE_ENV !== 'test') {
+      console.warn(
+        '[Algolia] ALGOLIA_APP_ID / ALGOLIA_ADMIN_API_KEY not configured — sync disabled. ' +
+          'Set both in `.env` and restart. (#173 / Algolia Slice 2)',
+      )
+    }
+    return null
+  }
+
+  client = algoliasearch(appId, adminKey)
+  return client
+}
+
+/** Test-only — clears the memoized client. */
+export function __resetAlgoliaClientForTests(): void {
+  client = null
+  triedInit = false
+}

--- a/src/search/algolia/index.ts
+++ b/src/search/algolia/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @description
+ * Public exports for the Algolia provider implementation. The factory
+ * at `src/search/index.ts` is the only thing that should import this
+ * module — collection configs go through `getSearchProvider()`.
+ *
+ * (#173 / Algolia migration Slice 2 — News POC.)
+ */
+export { algoliaProvider } from './provider'

--- a/src/search/algolia/provider.ts
+++ b/src/search/algolia/provider.ts
@@ -1,0 +1,58 @@
+/**
+ * @description
+ * `algoliaProvider` — `SearchProvider` implementation backed by Algolia.
+ * Activated when `SEARCH_PROVIDER=algolia` and the registry in
+ * `src/search/index.ts` includes the case (Slice 2 / #173 onwards).
+ *
+ * Slice 2 ships this for News only; Slice 3 (#174) wires up the
+ * remaining 7 collections.
+ */
+import { algoliasearch, type SearchClient as AlgoliaSearchClient } from 'algoliasearch'
+
+import type {
+  IndexSettings,
+  ProviderLocale,
+  SearchClient,
+  SearchProvider,
+  SyncHooks,
+  SyncHooksConfig,
+} from '../types'
+import { applyAlgoliaSettings, buildAlgoliaSyncHooks } from './sync'
+
+/** Build a frontend search-only client for a given locale. Keys are
+    deliberately separated: the admin key never leaves the server, the
+    NEXT_PUBLIC_ search-only key is safe to ship to the browser. */
+function buildSearchClient(_locale: ProviderLocale): SearchClient {
+  void _locale
+  const appId = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID || process.env.ALGOLIA_APP_ID || ''
+  const searchKey = process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY || ''
+  // When credentials aren't configured, fall back to a stub that
+  // returns empty results — same behavior as the Meilisearch provider's
+  // resilient client when its host is unreachable.
+  if (!appId || !searchKey) {
+    return {
+      search: async () => ({ results: [] }),
+    } as SearchClient
+  }
+  const client: AlgoliaSearchClient = algoliasearch(appId, searchKey)
+  // The `algoliasearch` client already exposes the `search` method that
+  // `react-instantsearch` expects; cast through to satisfy the
+  // `SearchProvider` shape (which intentionally allows extra props).
+  return client as unknown as SearchClient
+}
+
+export const algoliaProvider: SearchProvider = {
+  name: 'algolia',
+
+  getSyncHooks(config: SyncHooksConfig): SyncHooks {
+    return buildAlgoliaSyncHooks(config)
+  },
+
+  getSearchClient(locale: ProviderLocale): SearchClient {
+    return buildSearchClient(locale)
+  },
+
+  async applySettings(indexName: string, settings: IndexSettings): Promise<void> {
+    await applyAlgoliaSettings(indexName, settings)
+  },
+}

--- a/src/search/algolia/sync.ts
+++ b/src/search/algolia/sync.ts
@@ -1,0 +1,197 @@
+/**
+ * @description
+ * Algolia sync — Payload `afterChange` + `afterDelete` hooks that mirror
+ * Payload documents into per-locale Algolia indexes. Locale-isolated:
+ * a doc with only EN populated lands in `<index>_en` only, never in
+ * `<index>_fr` (per User Story 18).
+ *
+ * Sister to `src/search/meilisearch/sync.ts` — both implementations
+ * share the `SearchProvider` interface from `../types.ts`. Slice 2
+ * (#173) wires this up for the `news` collection only as a POC; Slice 3
+ * (#174) expands to the remaining 7 searchable collections.
+ *
+ * @notes
+ * - Per-locale tokenization happens server-side in Algolia; the
+ *   transformer just emits a flat record. The `_en` / `_fr` suffix on
+ *   the index drives Algolia's per-language stop-words + stemming.
+ * - Failures are swallowed so an Algolia outage doesn't block CMS saves
+ *   (matches the Meilisearch behavior + dual-write Slice 5 expectation).
+ */
+import type {
+  CollectionAfterChangeHook,
+  CollectionAfterDeleteHook,
+} from 'payload'
+
+import type { IndexSettings, ProviderLocale, SyncHooks, SyncHooksConfig } from '../types'
+import { getAlgoliaAdminClient } from './client'
+
+/** Default filterable / facet attributes — kept identical to the
+    Meilisearch defaults so a flag flip doesn't change facet behavior. */
+const DEFAULT_ATTRIBUTES_FOR_FACETING = [
+  'board',
+  'standard',
+  'content_type',
+  'file_type',
+  'date',
+  'status',
+]
+
+/** Default searchable attributes — Algolia ranks by attribute order, so
+    `title` first, then `summary`/`excerpt`, then body. */
+const DEFAULT_SEARCHABLE_ATTRIBUTES = [
+  'title',
+  'summary',
+  'excerpt',
+  'body',
+]
+
+const LOCALES: ProviderLocale[] = ['en', 'fr']
+
+/** Default transform — extracts common fields from a Payload document
+    into a flat Algolia record. Mirror of `meilisearch/sync.ts` so the
+    record shape is provider-agnostic. */
+function defaultTransform(doc: Record<string, unknown>): Record<string, unknown> {
+  const board = doc.board as Record<string, unknown> | string | undefined
+  const boardAbbreviation = typeof board === 'object' && board ? board.abbreviation : board
+
+  return {
+    objectID: String(doc.id),
+    title: doc.title || '',
+    slug: doc.slug || '',
+    summary: doc.summary || doc.excerpt || '',
+    body: doc.content || doc.body || '',
+    board: boardAbbreviation || '',
+    status: doc.status || '',
+    date: doc.publishedDate || doc.date || doc.createdAt || '',
+    content_type: doc.type || '',
+    updatedAt: doc.updatedAt || '',
+  }
+}
+
+/** Heuristic: a doc "has FR content" if either `slug.fr` or `title.fr`
+    is populated when the doc was fetched with `locale: 'all'`. We only
+    write to `<index>_fr` when this is true so we never index a stub
+    record into the FR locale. */
+function localeHasContent(doc: Record<string, unknown>, locale: ProviderLocale): boolean {
+  const lookup = (key: string) => {
+    const value = doc[key]
+    if (!value) return false
+    if (typeof value === 'string') return locale === 'en'
+    if (typeof value === 'object' && value !== null && locale in value) {
+      return Boolean((value as Record<string, unknown>)[locale])
+    }
+    return false
+  }
+  return lookup('title') || lookup('slug')
+}
+
+/** Track configured indexes so we don't re-issue settings on every sync. */
+const configuredIndexes = new Set<string>()
+
+/** Push searchable + faceting settings to an Algolia index. Idempotent
+    — Algolia merges the partial settings server-side. Used by both the
+    auto-configure path (first sync) and `AlgoliaProvider.applySettings`. */
+export async function applyAlgoliaSettings(
+  indexName: string,
+  settings: IndexSettings = {},
+): Promise<void> {
+  const client = getAlgoliaAdminClient()
+  if (!client) return
+
+  const searchable = settings.searchableAttributes ?? DEFAULT_SEARCHABLE_ATTRIBUTES
+  const faceting = settings.filterableAttributes ?? DEFAULT_ATTRIBUTES_FOR_FACETING
+
+  try {
+    await client.setSettings({
+      indexName,
+      indexSettings: {
+        searchableAttributes: searchable,
+        attributesForFaceting: faceting,
+        ...(settings.sortableAttributes
+          ? { customRanking: settings.sortableAttributes.map((attr) => `desc(${attr})`) }
+          : {}),
+      },
+    })
+  } catch (error) {
+    console.warn(`[Algolia] setSettings('${indexName}') failed:`, error)
+  }
+}
+
+/**
+ * Build Algolia sync hooks for a Payload collection. Splits writes
+ * across `<indexName>_en` and `<indexName>_fr` based on which locales
+ * have populated content on the doc.
+ *
+ * Exposed via `algoliaProvider.getSyncHooks(config)`; not normally
+ * imported directly.
+ */
+export function buildAlgoliaSyncHooks(config: SyncHooksConfig): SyncHooks {
+  const { indexName, collectionSlug = indexName, transform = defaultTransform } = config
+
+  const afterChange: CollectionAfterChangeHook = async ({ doc, req }) => {
+    const client = getAlgoliaAdminClient()
+    if (!client) return doc
+
+    try {
+      // Re-fetch with `locale: 'all'` so we can detect which locales
+      // have content (Payload's hook `doc` is locale-flattened).
+      const allLocales = (await req.payload.findByID({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        collection: collectionSlug as any,
+        id: (doc as Record<string, unknown>).id as string | number,
+        depth: 0,
+        locale: 'all',
+        overrideAccess: true,
+      })) as unknown as Record<string, unknown>
+
+      for (const locale of LOCALES) {
+        const localizedIndex = `${indexName}_${locale}`
+        if (!localeHasContent(allLocales, locale)) continue
+
+        // Re-fetch under each locale so transform sees the localized
+        // strings rather than the locale='all' object map.
+        const localized = (await req.payload.findByID({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          collection: collectionSlug as any,
+          id: allLocales.id as string | number,
+          depth: 3,
+          locale,
+          overrideAccess: true,
+        })) as unknown as Record<string, unknown>
+
+        if (!configuredIndexes.has(localizedIndex)) {
+          await applyAlgoliaSettings(localizedIndex)
+          configuredIndexes.add(localizedIndex)
+        }
+
+        await client.saveObject({
+          indexName: localizedIndex,
+          body: transform(localized),
+        })
+      }
+    } catch (error) {
+      console.error(`[Algolia] Failed to sync document to '${indexName}':`, error)
+    }
+
+    return doc
+  }
+
+  const afterDelete: CollectionAfterDeleteHook = async ({ doc }) => {
+    const client = getAlgoliaAdminClient()
+    if (!client || !doc) return
+
+    for (const locale of LOCALES) {
+      const localizedIndex = `${indexName}_${locale}`
+      try {
+        await client.deleteObject({
+          indexName: localizedIndex,
+          objectID: String((doc as Record<string, unknown>).id),
+        })
+      } catch (error) {
+        console.error(`[Algolia] Failed to delete document from '${localizedIndex}':`, error)
+      }
+    }
+  }
+
+  return { afterChange, afterDelete }
+}

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -15,6 +15,7 @@
  *
  * (#172 / Algolia migration Slice 1.)
  */
+import { algoliaProvider } from './algolia'
 import { meilisearchProvider } from './meilisearch'
 import {
   SEARCH_PROVIDER_ENV,
@@ -28,17 +29,7 @@ const cache = new Map<SearchProviderName, SearchProvider>()
 
 function resolveProviderName(): SearchProviderName {
   const raw = process.env[SEARCH_PROVIDER_ENV]?.toLowerCase().trim()
-  if (raw === 'algolia') {
-    // Slice 2+ ships the Algolia adapter behind a flag; until then,
-    // explicitly opting in falls through to the default + a warning so
-    // a misconfigured env doesn't silently disable search.
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(
-        `[search] SEARCH_PROVIDER=algolia is reserved (see #173). Falling back to 'meilisearch'.`,
-      )
-    }
-    return 'meilisearch'
-  }
+  if (raw === 'algolia') return 'algolia'
   return 'meilisearch'
 }
 
@@ -46,11 +37,19 @@ export function getSearchProvider(): SearchProvider {
   const name = resolveProviderName()
   const cached = cache.get(name)
   if (cached) return cached
-  // Currently `meilisearch` is the only registered provider; Slice 2+
-  // will add an `algolia` case below. The factory uses the env-driven
-  // name as the cache key so a future `SEARCH_PROVIDER=algolia` flip
-  // doesn't recompute Meili's resilient client.
-  const provider: SearchProvider = meilisearchProvider
+  let provider: SearchProvider
+  switch (name) {
+    case 'meilisearch':
+      provider = meilisearchProvider
+      break
+    case 'algolia':
+      provider = algoliaProvider
+      break
+    default: {
+      const exhaustive: never = name
+      throw new Error(`Unknown SEARCH_PROVIDER: ${exhaustive as string}`)
+    }
+  }
   cache.set(name, provider)
   return provider
 }

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -26,8 +26,13 @@ import type {
 /** Configuration handed to `getSyncHooks`. */
 export type SyncHooksConfig = {
   /** Logical index name (e.g. 'news', 'projects'). The provider may
-      append a locale suffix internally (Meilisearch: `news_en`). */
+      append a locale suffix internally (Meilisearch: `news_en`,
+      Algolia: `news_en` + `news_fr`). */
   indexName: string
+  /** Payload collection slug — required by per-locale providers
+      (Algolia) so the hook can re-fetch under each locale to detect
+      which locales have content. Defaults to `indexName`. */
+  collectionSlug?: string
   /** Optional transform from a populated Payload doc to the search
       record. Falls back to a provider-specific default. */
   transform?: (doc: Record<string, unknown>) => Record<string, unknown>


### PR DESCRIPTION
## Summary

Ships the **code** half of Algolia migration Slice 2. Default behavior unchanged (`SEARCH_PROVIDER` unset → Meilisearch). Flipping `SEARCH_PROVIDER=algolia` activates the new adapter once real credentials are in `.env`.

## What landed

- `src/search/algolia/{client,sync,provider,index}.ts` — full provider conforming to the Slice 1 interface
- `src/search/__tests__/provider-conformance.test.ts` — both providers pass the same 4-case contract (8 cases total)
- `infrastructure/algolia/settings.ts` — settings-as-code (News only for Slice 2)
- `scripts/algolia-backfill.mjs` — idempotent backfill, per-locale split
- `scripts/apply-algolia-settings.mjs` — push settings to Algolia (CI-callable)
- `.env.example` — added `SEARCH_PROVIDER` + `ALGOLIA_APP_ID` / `ALGOLIA_ADMIN_API_KEY` / `NEXT_PUBLIC_ALGOLIA_*` (`.env` NOT touched per CLAUDE.md)

## Per-locale isolation

`afterChange` re-fetches the doc with `locale: 'all'`, then for each of `[en, fr]` checks if `title` or `slug` is populated for that locale. Only writes the record into `<index>_<locale>` when the locale has content. EN-only doc → only `news_en`. (User Story 18.)

## HITL items (out of scope for this PR)

These need humans, not code:

1. **Stakeholder data-residency answer** (parent PRD hard blocker)
2. **Real Algolia account + admin/search keys** in production `.env`
3. **POC comparison report** at `.ai-reports/algolia-poc-results.md` — 10 queries × EN/FR/typo/diacritic, latency p50/p95, top-5 relevance, FR diacritics
4. **Go/no-go decision** recorded in `.ai-reports/AUDIT_LOG.md`

## Verification

- `tsc --noEmit` clean
- `npx vitest run` 341/341 (was 337 — +4 Algolia conformance cases)
- `SEARCH_PROVIDER` unset → `meilisearch` dispatch (default) → existing behavior unchanged

Refs #173 — code complete; HITL items remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)