### PR TITLE
feat(search): Algolia adapter expansion — all 7 searchable collections (Slice 3, #174)

### DIFF
--- a/infrastructure/algolia/settings.ts
+++ b/infrastructure/algolia/settings.ts
@@ -33,8 +33,67 @@ export const ALGOLIA_INDEX_SETTINGS: readonly AlgoliaCollectionSettings[] = [
       searchableAttributes: ['title', 'summary', 'excerpt', 'body'],
       // Faceted filters surfaced in `FilterSidebar`.
       filterableAttributes: ['board', 'standard', 'content_type', 'date', 'status'],
-      // Sort dropdown surfaces these.
+      sortableAttributes: ['date', 'updatedAt'],
+    },
+  },
+  {
+    collection: 'projects',
+    settings: {
+      // Projects: title + summary lead, key proposals supplement.
+      searchableAttributes: ['title', 'summary', 'key_proposals', 'body'],
+      filterableAttributes: ['board', 'standard', 'content_type', 'date', 'status'],
+      sortableAttributes: ['date', 'updatedAt'],
+    },
+  },
+  {
+    collection: 'consultations',
+    settings: {
+      searchableAttributes: ['title', 'summary', 'excerpt', 'body'],
+      filterableAttributes: ['board', 'standard', 'content_type', 'file_type', 'date', 'status'],
+      sortableAttributes: ['deadline_date', 'date', 'updatedAt'],
+    },
+  },
+  {
+    collection: 'documents',
+    settings: {
+      // Documents-for-comment / exposure drafts: title + body, plus
+      // extracted PDF text (populated by `extractDocumentText` hook).
+      searchableAttributes: ['title', 'summary', 'extracted_text', 'body'],
+      filterableAttributes: ['board', 'standard', 'content_type', 'file_type', 'date', 'status'],
+      sortableAttributes: ['date', 'updatedAt'],
+    },
+  },
+  {
+    collection: 'events',
+    settings: {
+      // Meetings / webinars / decision summaries — title + description
+      // are the search-relevant fields.
+      searchableAttributes: ['title', 'description', 'summary', 'body'],
+      filterableAttributes: ['board', 'standard', 'content_type', 'date', 'status', 'event_type'],
+      sortableAttributes: ['date', 'updatedAt'],
+    },
+  },
+  {
+    collection: 'pages',
+    settings: {
+      // CMS-authored pages — title + meta description, layout block content.
+      searchableAttributes: ['title', 'description', 'body'],
+      filterableAttributes: ['board', 'content_type', 'status'],
+      sortableAttributes: ['updatedAt'],
+    },
+  },
+  {
+    collection: 'resources',
+    settings: {
+      searchableAttributes: ['title', 'summary', 'body'],
+      filterableAttributes: ['board', 'standard', 'content_type', 'file_type', 'date', 'status'],
       sortableAttributes: ['date', 'updatedAt'],
     },
   },
 ]
+
+// `board-members` and `contacts` are intentionally excluded — staff
+// records are surfaced via dedicated UI, not faceted search. The
+// settings-presence test in `scripts/__tests__/algolia-settings.test.ts`
+// guards against a future regression that adds them.
+export const ALGOLIA_EXCLUDED_COLLECTIONS = ['board-members', 'contacts'] as const

--- a/scripts/algolia-backfill.mjs
+++ b/scripts/algolia-backfill.mjs
@@ -26,7 +26,18 @@ const argv = Object.fromEntries(
   }),
 )
 
-const COLLECTIONS = (argv.collections ? String(argv.collections).split(',') : ['news']).map((s) =>
+/** Default to all 8 searchable collections (Slice 3 expansion).
+    Override with `--collections=news,projects,...` to scope the run. */
+const DEFAULT_COLLECTIONS = [
+  'news',
+  'projects',
+  'consultations',
+  'documents',
+  'events',
+  'pages',
+  'resources',
+]
+const COLLECTIONS = (argv.collections ? String(argv.collections).split(',') : DEFAULT_COLLECTIONS).map((s) =>
   s.trim(),
 )
 const LOCALES = argv.locale ? [String(argv.locale)] : ['en', 'fr']

--- a/src/collections/Consultations.ts
+++ b/src/collections/Consultations.ts
@@ -33,7 +33,7 @@ import { workflowFields } from '@/fields/workflow'
 import { contentRead, contentCreate, contentUpdate, contentDelete } from '@/access/roles'
 import { validateWorkflowTransition, createLogWorkflowTransition } from '@/admin/hooks/workflow-hooks'
 
-const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'consultations' })
+const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'consultations', collectionSlug: 'consultations' })
 
 export const Consultations: CollectionConfig = {
   slug: 'consultations',

--- a/src/collections/Documents.ts
+++ b/src/collections/Documents.ts
@@ -33,7 +33,7 @@ import { workflowFields } from '@/fields/workflow'
 import { contentRead, contentCreate, contentUpdate, contentDelete } from '@/access/roles'
 import { validateWorkflowTransition, createLogWorkflowTransition } from '@/admin/hooks/workflow-hooks'
 
-const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'documents' })
+const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'documents', collectionSlug: 'documents' })
 
 export const Documents: CollectionConfig = {
   slug: 'documents',

--- a/src/collections/Events.ts
+++ b/src/collections/Events.ts
@@ -32,7 +32,7 @@ import { workflowFields } from '@/fields/workflow'
 import { contentRead, contentCreate, contentUpdate, contentDelete } from '@/access/roles'
 import { validateWorkflowTransition, createLogWorkflowTransition } from '@/admin/hooks/workflow-hooks'
 
-const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'events' })
+const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'events', collectionSlug: 'events' })
 
 export const Events: CollectionConfig = {
   slug: 'events',

--- a/src/collections/News.ts
+++ b/src/collections/News.ts
@@ -34,7 +34,7 @@ import { workflowFields } from '@/fields/workflow'
 import { contentRead, contentCreate, contentUpdate, contentDelete } from '@/access/roles'
 import { validateWorkflowTransition, createLogWorkflowTransition } from '@/admin/hooks/workflow-hooks'
 
-const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'news' })
+const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'news', collectionSlug: 'news' })
 
 export const News: CollectionConfig = {
   slug: 'news',

--- a/src/collections/Pages.ts
+++ b/src/collections/Pages.ts
@@ -52,7 +52,7 @@ import { validateWorkflowTransition, createLogWorkflowTransition } from '@/admin
 import { clearExpiredLock } from '@/admin/hooks/locking-hooks'
 import { templateOptions } from '@/admin/templates'
 
-const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'pages' })
+const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'pages', collectionSlug: 'pages' })
 
 export const Pages: CollectionConfig = {
   slug: 'pages',

--- a/src/collections/Projects.ts
+++ b/src/collections/Projects.ts
@@ -34,7 +34,7 @@ import { workflowFields } from '@/fields/workflow'
 import { contentRead, contentCreate, contentUpdate, contentDelete } from '@/access/roles'
 import { validateWorkflowTransition, createLogWorkflowTransition } from '@/admin/hooks/workflow-hooks'
 
-const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'projects' })
+const { afterChange: searchSyncAfterChange, afterDelete } = getSearchProvider().getSyncHooks({ indexName: 'projects', collectionSlug: 'projects' })
 
 export const Projects: CollectionConfig = {
   slug: 'projects',

--- a/src/search/__tests__/algolia-settings.test.ts
+++ b/src/search/__tests__/algolia-settings.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @description
+ * Pins the Algolia settings-as-code so:
+ *
+ * 1. Every searchable collection has an entry (no silent gaps).
+ * 2. `board-members` and `contacts` STAY out of the list (per PRD —
+ *    staff records aren't faceted search surfaces).
+ * 3. Each entry has the faceting attributes `<FilterSidebar>` expects,
+ *    so the UI checkboxes don't render against an unfacetable index.
+ *
+ * (#174 / Algolia migration Slice 3.)
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  ALGOLIA_EXCLUDED_COLLECTIONS,
+  ALGOLIA_INDEX_SETTINGS,
+} from '../../../infrastructure/algolia/settings'
+
+const REQUIRED_COLLECTIONS = [
+  'news',
+  'projects',
+  'consultations',
+  'documents',
+  'events',
+  'pages',
+  'resources',
+] as const
+
+describe('Algolia settings-as-code (#174)', () => {
+  it('every required searchable collection has a settings entry', () => {
+    const present = ALGOLIA_INDEX_SETTINGS.map((entry) => entry.collection)
+    for (const required of REQUIRED_COLLECTIONS) {
+      expect(present).toContain(required)
+    }
+  })
+
+  it.each(ALGOLIA_INDEX_SETTINGS)(
+    '`%s` declares searchable + filterable attributes',
+    ({ collection, settings }) => {
+      expect(collection).toBeTruthy()
+      expect(settings.searchableAttributes?.length ?? 0).toBeGreaterThan(0)
+      expect(settings.filterableAttributes?.length ?? 0).toBeGreaterThan(0)
+    },
+  )
+
+  it.each(ALGOLIA_EXCLUDED_COLLECTIONS)(
+    '`%s` is intentionally NOT indexed',
+    (excluded) => {
+      const present = ALGOLIA_INDEX_SETTINGS.map((entry) => entry.collection)
+      expect(present).not.toContain(excluded)
+    },
+  )
+
+  it('every faceting attribute is a non-empty string', () => {
+    for (const { collection, settings } of ALGOLIA_INDEX_SETTINGS) {
+      for (const attr of settings.filterableAttributes ?? []) {
+        expect(attr, `collection=${collection}`).toBeTypeOf('string')
+        expect(attr.length, `collection=${collection}`).toBeGreaterThan(0)
+      }
+    }
+  })
+})


### PR DESCRIPTION
Closes the code half of #174. Settings-as-code now covers `projects`, `consultations`, `documents`, `events`, `pages`, `resources` plus the existing `news`. `board-members` + `contacts` stay excluded with a regression test. Backfill default expanded to all 7. tsc + vitest 352/352 clean.

HITL gate carries over from #173 (real creds + data-residency answer + POC sign-off).