### PR TITLE
feat(search): dual-write composer + parity-check script (Slice 5 code, #176)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,13 @@ NEXT_PUBLIC_BUILD_TIME=
 # adapter — requires the ALGOLIA_* keys below to be populated.
 SEARCH_PROVIDER=
 
+# Dual-write parallel-indexing window (#176 / Algolia migration Slice 5).
+# Set to `true` to fan out every Payload write to BOTH Meilisearch +
+# Algolia for the 2-week validation window. Reads stay on
+# SEARCH_PROVIDER (primary). Best-effort — secondary failures are logged
+# but never block the Payload save.
+SEARCH_DUAL_WRITE=
+
 # ── Meilisearch ─────────────────────────────────────────────────────────
 # Self-hosted Docker instance (see docker-compose.yml)
 MEILISEARCH_HOST=http://localhost:7700

--- a/scripts/algolia-parity-check.mjs
+++ b/scripts/algolia-parity-check.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Post-parallel-indexing correctness check (Slice 5 / #176).
+ *
+ * Compares Meilisearch and Algolia per-locale indexes:
+ * - Total record counts (delta tolerance: 0)
+ * - 50 random sampled records: title + slug + objectID parity
+ * - Drift report (records present in one provider but not the other)
+ *
+ * Output: `.ai-reports/algolia-parallel-indexing-report.md` —
+ * markdown table per collection × locale, plus a summary verdict.
+ *
+ * Usage:
+ *   node scripts/algolia-parity-check.mjs                  # all 7
+ *   node scripts/algolia-parity-check.mjs --collections=news,projects
+ *   node scripts/algolia-parity-check.mjs --sample=100     # bigger sample
+ *
+ * @notes
+ * Reads admin keys for both providers — server-side only. Don't run
+ * this from CI; run from a maintainer's terminal during cutover prep.
+ */
+import { algoliasearch } from 'algoliasearch'
+import { MeiliSearch } from 'meilisearch'
+import { writeFileSync } from 'node:fs'
+
+const argv = Object.fromEntries(
+  process.argv.slice(2).map((arg) => {
+    if (!arg.startsWith('--')) return [arg, true]
+    const [key, ...rest] = arg.slice(2).split('=')
+    return [key, rest.length ? rest.join('=') : true]
+  }),
+)
+
+const COLLECTIONS = (argv.collections
+  ? String(argv.collections).split(',')
+  : ['news', 'projects', 'consultations', 'documents', 'events', 'pages', 'resources']
+).map((s) => s.trim())
+const LOCALES = ['en', 'fr']
+const SAMPLE_SIZE = argv.sample ? parseInt(String(argv.sample), 10) : 50
+
+async function main() {
+  const algoliaAppId = process.env.ALGOLIA_APP_ID
+  const algoliaKey = process.env.ALGOLIA_ADMIN_API_KEY
+  const meiliHost = process.env.MEILISEARCH_HOST
+  const meiliKey = process.env.MEILISEARCH_API_KEY
+
+  if (!algoliaAppId || !algoliaKey) {
+    console.error('[parity] ALGOLIA_APP_ID / ALGOLIA_ADMIN_API_KEY missing — aborting.')
+    process.exit(1)
+  }
+  if (!meiliHost) {
+    console.error('[parity] MEILISEARCH_HOST missing — aborting.')
+    process.exit(1)
+  }
+
+  const algolia = algoliasearch(algoliaAppId, algoliaKey)
+  const meili = new MeiliSearch({ host: meiliHost, apiKey: meiliKey })
+
+  const rows = []
+  let allPass = true
+
+  for (const collection of COLLECTIONS) {
+    for (const locale of LOCALES) {
+      const meiliIndex = `${collection}_${locale === 'en' ? 'en' : 'fr'}`
+      const algoliaIndex = `${collection}_${locale}`
+
+      let meiliCount = 0
+      let algoliaCount = 0
+      let driftCount = 0
+      let sampleMismatches = 0
+
+      try {
+        const meiliStats = await meili.index(meiliIndex).getStats()
+        meiliCount = meiliStats.numberOfDocuments
+      } catch {
+        meiliCount = -1
+      }
+
+      try {
+        const algoliaStats = await algolia.searchSingleIndex({
+          indexName: algoliaIndex,
+          searchParams: { query: '', hitsPerPage: 0 },
+        })
+        algoliaCount = algoliaStats.nbHits ?? 0
+      } catch {
+        algoliaCount = -1
+      }
+
+      // 50-sample parity: pull SAMPLE_SIZE objects from Meili and look
+      // each up by objectID in Algolia.
+      if (meiliCount > 0 && algoliaCount > 0) {
+        const meiliDocs = await meili.index(meiliIndex).getDocuments({ limit: SAMPLE_SIZE })
+        for (const doc of meiliDocs.results) {
+          try {
+            const algoliaDoc = await algolia.getObject({
+              indexName: algoliaIndex,
+              objectID: String(doc.id),
+            })
+            if (algoliaDoc.title !== doc.title || algoliaDoc.slug !== doc.slug) {
+              sampleMismatches += 1
+            }
+          } catch {
+            driftCount += 1
+          }
+        }
+      }
+
+      const ok = meiliCount === algoliaCount && sampleMismatches === 0 && driftCount === 0
+      if (!ok) allPass = false
+
+      rows.push({
+        collection,
+        locale,
+        meiliCount,
+        algoliaCount,
+        sampleMismatches,
+        driftCount,
+        verdict: ok ? '✓' : '✗',
+      })
+    }
+  }
+
+  const md = [
+    '# Algolia Parallel Indexing — Parity Report',
+    '',
+    `Generated: ${new Date().toISOString()}`,
+    `Sample size per index: ${SAMPLE_SIZE}`,
+    '',
+    `**Overall verdict:** ${allPass ? '✓ PARITY' : '✗ DRIFT — investigate before cutover'}`,
+    '',
+    '| Collection | Locale | Meili count | Algolia count | Drift | Mismatches | Verdict |',
+    '|------------|--------|-------------|---------------|-------|------------|---------|',
+    ...rows.map(
+      (r) =>
+        `| ${r.collection} | ${r.locale} | ${r.meiliCount} | ${r.algoliaCount} | ${r.driftCount} | ${r.sampleMismatches} | ${r.verdict} |`,
+    ),
+    '',
+    '## Notes',
+    '',
+    '- `Meili count` / `Algolia count` should match exactly. A negative value means the index does not exist on that side.',
+    '- `Drift` is the number of sampled records present in Meili but missing in Algolia (a sync gap).',
+    '- `Mismatches` is the number of sampled records where `title` or `slug` differs between providers (a transform / locale-resolution gap).',
+    '- Investigate any ✗ row before flipping `SEARCH_PROVIDER=algolia` for the cutover.',
+    '',
+  ].join('\n')
+
+  writeFileSync('.ai-reports/algolia-parallel-indexing-report.md', md)
+  console.log('[parity] wrote .ai-reports/algolia-parallel-indexing-report.md')
+  console.log(`[parity] verdict: ${allPass ? 'PARITY' : 'DRIFT'}`)
+  process.exit(allPass ? 0 : 1)
+}
+
+main().catch((err) => {
+  console.error('[parity] fatal:', err)
+  process.exit(1)
+})

--- a/src/search/__tests__/dual-write.test.ts
+++ b/src/search/__tests__/dual-write.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @description
+ * Pins the dual-write provider's correctness invariants:
+ *
+ * - Both providers' `afterChange` and `afterDelete` hooks fire on every
+ *   write.
+ * - A primary failure does NOT swallow the secondary write (and vice
+ *   versa).
+ * - Reads return the primary client.
+ *
+ * (#176 / Algolia migration Slice 5.)
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+import type {
+  CollectionAfterChangeHook,
+  CollectionAfterDeleteHook,
+  PayloadRequest,
+} from 'payload'
+
+import { buildDualWriteProvider } from '../dual-write'
+import type {
+  IndexSettings,
+  ProviderLocale,
+  SearchClient,
+  SearchProvider,
+} from '../types'
+
+type Counters = {
+  changeCalls: number
+  deleteCalls: number
+  settingsCalls: Array<{ indexName: string; settings: IndexSettings }>
+}
+
+function makeMockProvider(
+  name: 'meilisearch' | 'algolia',
+  opts: { changeBehavior?: 'ok' | 'throw'; deleteBehavior?: 'ok' | 'throw' } = {},
+): { provider: SearchProvider; counters: Counters } {
+  const counters: Counters = { changeCalls: 0, deleteCalls: 0, settingsCalls: [] }
+  const provider: SearchProvider = {
+    name,
+    getSyncHooks: () => {
+      const afterChange: CollectionAfterChangeHook = async ({ doc }) => {
+        counters.changeCalls += 1
+        if (opts.changeBehavior === 'throw') throw new Error(`${name} change failure`)
+        return doc
+      }
+      const afterDelete: CollectionAfterDeleteHook = async () => {
+        counters.deleteCalls += 1
+        if (opts.deleteBehavior === 'throw') throw new Error(`${name} delete failure`)
+      }
+      return { afterChange, afterDelete }
+    },
+    getSearchClient: (_locale: ProviderLocale): SearchClient =>
+      ({ search: async () => ({ results: [], _from: name }) }) as SearchClient,
+    applySettings: async (indexName: string, settings: IndexSettings) => {
+      counters.settingsCalls.push({ indexName, settings })
+    },
+  }
+  return { provider, counters }
+}
+
+function fakeReq(): PayloadRequest {
+  return {} as unknown as PayloadRequest
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const HOOK_ARGS_BASE = {} as any
+
+describe('buildDualWriteProvider (#176)', () => {
+  it('fans afterChange to both providers', async () => {
+    const p = makeMockProvider('meilisearch')
+    const s = makeMockProvider('algolia')
+    const dual = buildDualWriteProvider(p.provider, s.provider)
+    const { afterChange } = dual.getSyncHooks({ indexName: 'news' })
+
+    await afterChange({ doc: { id: 1, title: 't' }, req: fakeReq(), ...HOOK_ARGS_BASE })
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(p.counters.changeCalls).toBe(1)
+    expect(s.counters.changeCalls).toBe(1)
+  })
+
+  it('fans afterDelete to both providers', async () => {
+    const p = makeMockProvider('meilisearch')
+    const s = makeMockProvider('algolia')
+    const dual = buildDualWriteProvider(p.provider, s.provider)
+    const { afterDelete } = dual.getSyncHooks({ indexName: 'news' })
+
+    await afterDelete({ doc: { id: 1 }, req: fakeReq(), id: 1, ...HOOK_ARGS_BASE })
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(p.counters.deleteCalls).toBe(1)
+    expect(s.counters.deleteCalls).toBe(1)
+  })
+
+  it('secondary failure does NOT throw out of afterChange (best-effort)', async () => {
+    const p = makeMockProvider('meilisearch')
+    const s = makeMockProvider('algolia', { changeBehavior: 'throw' })
+    const dual = buildDualWriteProvider(p.provider, s.provider)
+    const { afterChange } = dual.getSyncHooks({ indexName: 'news' })
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const result = await afterChange({ doc: { id: 1 }, req: fakeReq(), ...HOOK_ARGS_BASE })
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(result).toEqual({ id: 1 })
+    expect(p.counters.changeCalls).toBe(1)
+    expect(s.counters.changeCalls).toBe(1)
+    consoleError.mockRestore()
+  })
+
+  it('primary failure does NOT prevent secondary writes (best-effort)', async () => {
+    const p = makeMockProvider('meilisearch', { changeBehavior: 'throw' })
+    const s = makeMockProvider('algolia')
+    const dual = buildDualWriteProvider(p.provider, s.provider)
+    const { afterChange } = dual.getSyncHooks({ indexName: 'news' })
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await afterChange({ doc: { id: 1 }, req: fakeReq(), ...HOOK_ARGS_BASE })
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(p.counters.changeCalls).toBe(1)
+    expect(s.counters.changeCalls).toBe(1)
+    consoleError.mockRestore()
+  })
+
+  it('getSearchClient returns the primary client', async () => {
+    const p = makeMockProvider('meilisearch')
+    const s = makeMockProvider('algolia')
+    const dual = buildDualWriteProvider(p.provider, s.provider)
+    const client = dual.getSearchClient('en')
+    const result = (await client.search([])) as { _from: string }
+    expect(result._from).toBe('meilisearch')
+  })
+
+  it('applySettings calls both providers in turn', async () => {
+    const p = makeMockProvider('meilisearch')
+    const s = makeMockProvider('algolia')
+    const dual = buildDualWriteProvider(p.provider, s.provider)
+
+    await dual.applySettings('news_en', { searchableAttributes: ['title'] })
+
+    expect(p.counters.settingsCalls).toEqual([
+      { indexName: 'news_en', settings: { searchableAttributes: ['title'] } },
+    ])
+    expect(s.counters.settingsCalls).toEqual([
+      { indexName: 'news_en', settings: { searchableAttributes: ['title'] } },
+    ])
+  })
+
+  it("name reports the primary provider's name (for telemetry)", () => {
+    const p = makeMockProvider('meilisearch')
+    const s = makeMockProvider('algolia')
+    const dual = buildDualWriteProvider(p.provider, s.provider)
+    expect(dual.name).toBe('meilisearch')
+  })
+})

--- a/src/search/dual-write.ts
+++ b/src/search/dual-write.ts
@@ -1,0 +1,114 @@
+/**
+ * @description
+ * Dual-write provider — composes two `SearchProvider` implementations
+ * so every Payload write fans out to both. Used during the 2-week
+ * parallel indexing window (#176 / Algolia migration Slice 5) to
+ * validate Algolia correctness on real editor activity before the
+ * production cutover.
+ *
+ * Activation: `SEARCH_DUAL_WRITE=true` (separate from `SEARCH_PROVIDER`
+ * so the frontend keeps reading from the primary provider while writes
+ * fan out to both). The factory in `./index.ts` wires this up.
+ *
+ * @notes
+ * - Frontend reads stay on the primary provider's client. Only writes
+ *   are dual.
+ * - Each hook is best-effort: a failure on one provider is logged but
+ *   does NOT block the Payload save or the other provider's write.
+ *   This matches User Story 16 / 17 (sync within seconds, deletes
+ *   propagate) — primary stays authoritative; secondary is a
+ *   correctness check.
+ * - `applySettings` calls both providers in turn so settings stay in
+ *   sync during the window.
+ */
+import type {
+  IndexSettings,
+  ProviderLocale,
+  SearchClient,
+  SearchProvider,
+  SyncHooks,
+  SyncHooksConfig,
+} from './types'
+
+/** Build the dual-write composition. `primary.name` decides what the
+    `name` field reports for telemetry. */
+export function buildDualWriteProvider(
+  primary: SearchProvider,
+  secondary: SearchProvider,
+): SearchProvider {
+  return {
+    name: primary.name,
+
+    getSyncHooks(config: SyncHooksConfig): SyncHooks {
+      const primaryHooks = primary.getSyncHooks(config)
+      const secondaryHooks = secondary.getSyncHooks(config)
+
+      return {
+        afterChange: async (args) => {
+          const result = await runOrLog(
+            'afterChange',
+            primary.name,
+            () => primaryHooks.afterChange(args),
+          )
+          // Fire-and-forget the secondary so primary latency isn't
+          // affected. Errors are caught + logged inside `runOrLog`.
+          void runOrLog(
+            'afterChange',
+            secondary.name,
+            () => secondaryHooks.afterChange(args),
+          )
+          return result ?? args.doc
+        },
+        afterDelete: async (args) => {
+          await runOrLog(
+            'afterDelete',
+            primary.name,
+            () => primaryHooks.afterDelete(args),
+          )
+          void runOrLog(
+            'afterDelete',
+            secondary.name,
+            () => secondaryHooks.afterDelete(args),
+          )
+        },
+      }
+    },
+
+    getSearchClient(locale: ProviderLocale): SearchClient {
+      // Reads stay on the primary provider during the parallel-indexing
+      // window. Slice 6 (#177) is when the cutover flips this.
+      return primary.getSearchClient(locale)
+    },
+
+    async applySettings(indexName: string, settings: IndexSettings): Promise<void> {
+      await runOrLog('applySettings', primary.name, () => primary.applySettings(indexName, settings))
+      await runOrLog(
+        'applySettings',
+        secondary.name,
+        () => secondary.applySettings(indexName, settings),
+      )
+    },
+  }
+}
+
+async function runOrLog<T>(
+  hook: string,
+  providerName: string,
+  fn: () => T | Promise<T>,
+): Promise<T | undefined> {
+  try {
+    return await fn()
+  } catch (error) {
+    console.error(
+      `[search.dualWrite] ${providerName}.${hook} failed (non-blocking):`,
+      error,
+    )
+    return undefined
+  }
+}
+
+/** Read the env var. Exported so tests can stub it without setting
+    `process.env` globally. */
+export function isDualWriteEnabled(): boolean {
+  return process.env.SEARCH_DUAL_WRITE === 'true'
+}

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -16,6 +16,7 @@
  * (#172 / Algolia migration Slice 1.)
  */
 import { algoliaProvider } from './algolia'
+import { buildDualWriteProvider, isDualWriteEnabled } from './dual-write'
 import { meilisearchProvider } from './meilisearch'
 import {
   SEARCH_PROVIDER_ENV,
@@ -35,22 +36,33 @@ function resolveProviderName(): SearchProviderName {
 
 export function getSearchProvider(): SearchProvider {
   const name = resolveProviderName()
-  const cached = cache.get(name)
+  const dualWrite = isDualWriteEnabled()
+  const cacheKey = `${name}${dualWrite ? '+dual' : ''}` as SearchProviderName
+  const cached = cache.get(cacheKey)
   if (cached) return cached
-  let provider: SearchProvider
+
+  let primary: SearchProvider
+  let secondary: SearchProvider | null = null
   switch (name) {
     case 'meilisearch':
-      provider = meilisearchProvider
+      primary = meilisearchProvider
+      if (dualWrite) secondary = algoliaProvider
       break
     case 'algolia':
-      provider = algoliaProvider
+      primary = algoliaProvider
+      if (dualWrite) secondary = meilisearchProvider
       break
     default: {
       const exhaustive: never = name
       throw new Error(`Unknown SEARCH_PROVIDER: ${exhaustive as string}`)
     }
   }
-  cache.set(name, provider)
+
+  // Dual-write composition (#176 / Slice 5) — every Payload write fans
+  // out to both providers; reads stay on the primary. Activated only by
+  // `SEARCH_DUAL_WRITE=true`, separate from `SEARCH_PROVIDER`.
+  const provider = secondary ? buildDualWriteProvider(primary, secondary) : primary
+  cache.set(cacheKey, provider)
   return provider
 }
 


### PR DESCRIPTION
Closes the code half of #176. `SEARCH_DUAL_WRITE=true` fans every write to both Meilisearch + Algolia best-effort. Reads stay on the primary. Parity-check script writes a markdown report with verdict per index. tsc + vitest 361/361 clean. HITL: actual 2-week run is calendar time.