### PR TITLE
fix(admin-shell): /admin/builder (no :id) redirects to /admin/collections/pages (#162)

### DIFF
--- a/src/admin/views/PageBuilderIndex.tsx
+++ b/src/admin/views/PageBuilderIndex.tsx
@@ -1,0 +1,22 @@
+/**
+ * @description
+ * Tiny redirect view at `/admin/builder` (no `:id` segment). Bounces
+ * to `/admin/collections/pages` so typing the URL directly doesn't
+ * land on Payload's generic 404. (#162 / QA-114)
+ *
+ * The action-bar entry on Pages-collection edit views still routes to
+ * `/admin/builder/<page-id>` (the real builder). This is a cheap fix
+ * for the gap until a proper page-picker landing ships (option B from
+ * the issue).
+ *
+ * @notes
+ * - Server component — `redirect()` from `next/navigation` is the
+ *   canonical way to issue a 307 redirect from an RSC.
+ * - Default export is required by Payload's `views.*.Component`
+ *   path-string registration.
+ */
+import { redirect } from 'next/navigation'
+
+export default function PageBuilderIndex() {
+  redirect('/admin/collections/pages')
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -120,6 +120,13 @@ export default buildConfig({
           Component: '/admin/views/PageBuilder',
           path: '/builder/:id',
         },
+        // Bare `/admin/builder` (no `:id`) used to hit Payload's 404.
+        // This redirect view bounces to the Pages collection so direct
+        // URL typing lands somewhere sensible. (#162 / QA-114)
+        pageBuilderIndex: {
+          Component: '/admin/views/PageBuilderIndex',
+          path: '/builder',
+        },
         workbox: {
           Component: '/admin/views/Workbox',
           path: '/workbox',


### PR DESCRIPTION
Closes #162. Tiny RSC at /admin/builder bounces to the Pages collection so direct URL typing doesn't land on Payload's 404. Real builder at /admin/builder/<id> unchanged.