### PR TITLE
fix(i18n): wire NewsletterCTA + 4 other components through next-intl (#228)

### DIFF
--- a/.ai-reports/i18n-coverage-audit-2026-05-04.md
+++ b/.ai-reports/i18n-coverage-audit-2026-05-04.md
@@ -1,0 +1,108 @@
+# i18n Coverage Audit — Hardcoded English on `/fr`
+
+**Date:** 2026-05-04
+**Trigger:** Follow-up to #215 / PR #227 (fr.json diacritics). Hypothesis: even with fr.json corrected, components may render hardcoded English directly, bypassing `next-intl` entirely.
+**Method:** Static analysis of `src/components/**/*.tsx` for files lacking `useTranslations`/`getTranslations` imports + JSDOM scan of rendered `/fr` HTML for English-marker words.
+**Pages scanned:** `/fr`, `/fr/recherche`, `/fr/projets-actifs`, `/fr/nous-joindre`, `/fr/consultations-ouvertes`.
+
+## TL;DR
+
+Two confirmed hardcoded-English bugs render on **every** `/fr` page. Translation keys already exist for both — the components just never call `useTranslations`.
+
+| # | Component | Visible on `/fr` | Translation key exists? | Severity |
+|---|---|---|---|---|
+| 1 | `NewsletterCTA.tsx` (8+ strings) | YES — footer, every page | YES — `messages/{en,fr}.json` → `newsletter.*` | **P1** |
+| 2 | `SiteHeader.tsx` (1 string) | YES — header, every page | YES — `nav.primaryNavLabel` ("Navigation principale") | **P2** (a11y only) |
+| 3 | `SearchModal.tsx`, `MobileMenu.tsx`, `AnchorNav.tsx` | NO (interaction-mounted) | Mixed | **P3** (latent — lights up on user action) |
+
+## #1 — NewsletterCTA.tsx (P1)
+
+**File:** `src/components/NewsletterCTA.tsx`
+**Mounted in:** site footer (`SiteFooter.tsx`) → renders on every public page
+**Behavior on `/fr`:** Every newsletter string renders in English. Confirmed in DOM:
+
+```
+$ grep -E "Subscribe|Email address" /tmp/fr-home.html
+… <label>Email address</label>
+… <button>Subscribe</button>
+```
+
+### Hardcoded strings
+| Line | String | Existing key |
+|---|---|---|
+| 35 | `'Trusted by 3,000+ professionals across Canada'` (default heading) | none — needs `newsletter.heading` (or new `newsletter.headingFallback`) |
+| 50 | `'Please enter a valid email address.'` (validation) | `newsletter.invalidEmail` ✅ |
+| 67 | `'Something went wrong. Please try again.'` (error) | none — needs `newsletter.unknownError` |
+| 81 | `'Thank you for subscribing!'` (success) | `newsletter.success` ✅ |
+| 87 | `'Email address'` (sr-only label) | none — needs `forms.emailAddress` ✅ ("Adresse courriel *") OR new `newsletter.emailLabel` |
+| 97 | `'Enter your email'` (placeholder) | `newsletter.placeholder` ✅ |
+| 116 | `'Subscribing...'` / `'Subscribe'` (button) | `newsletter.subscribe` ✅ + needs `newsletter.subscribing` |
+| 133 | `'Follow us on LinkedIn'` (link) | none — needs `newsletter.linkedin` |
+
+### Fix sketch
+
+```tsx
+'use client'
+import { useTranslations } from 'next-intl'
+
+export function NewsletterCTA({ heading, description, className = '' }: Props) {
+  const t = useTranslations('newsletter')
+  // …
+  setErrorMessage(t('invalidEmail'))
+  // …
+  return (
+    <div className={className.trim()} data-testid="newsletter-cta">
+      {(heading ?? t('heading')) && <h2 …>{heading ?? t('heading')}</h2>}
+      …
+      <label htmlFor="newsletter-email" className="sr-only">{t('emailLabel')}</label>
+      <input … placeholder={t('placeholder')} … />
+      <Button …>{status === 'submitting' ? t('subscribing') : t('subscribe')}</Button>
+      …
+    </div>
+  )
+}
+```
+
+### Translation key additions (en.json + fr.json)
+- `newsletter.headingFallback` — "Trusted by 3,000+ professionals across Canada" / "Approuvé par plus de 3 000 professionnels au Canada"
+- `newsletter.unknownError` — "Something went wrong. Please try again." / "Une erreur est survenue. Veuillez réessayer."
+- `newsletter.emailLabel` — "Email address" / "Adresse courriel"
+- `newsletter.subscribing` — "Subscribing…" / "Inscription en cours…"
+- `newsletter.linkedin` — "Follow us on LinkedIn" / "Suivez-nous sur LinkedIn"
+
+## #2 — SiteHeader.tsx (P2 — a11y only)
+
+**File:** `src/components/layout/SiteHeader.tsx:204`
+**Issue:** `aria-label="Primary navigation"` is hardcoded English. The translation key `nav.primaryNavLabel` ("Navigation principale" / "Primary navigation") already exists.
+**Visible on /fr DOM:**
+
+```
+$ grep aria-label="Primary /tmp/fr-home.html
+aria-label="Primary navigation"
+```
+
+**Fix:** swap the literal for `t('primaryNavLabel')` from the existing `useTranslations('nav')` instance.
+
+## #3 — Latent (interaction-mounted)
+
+These don't render server-side so they don't appear in the DOM scan, but they will surface as English the moment a user opens the menu / search:
+
+- `src/components/SearchModal.tsx`:
+  - `aria-label="Search"`, `aria-label="Close search"`, `aria-label="Search query"`
+  - `placeholder="Projects, meetings, documents, and more."`
+  (Note: there's a near-duplicate translated string at `search.searchInputPlaceholder` — "Projets, réunions, documents et plus.")
+- `src/components/layout/MobileMenu.tsx`:
+  - `aria-label="Close menu"`, `aria-label="Mobile navigation"`
+  - `placeholder="Search projects, standards..."`
+- `src/components/AnchorNav.tsx`:
+  - `aria-label="On this page"`
+
+All three should be wired through `useTranslations('nav' | 'search')` with the existing keys (`nav.closeMenu`, `nav.mobileNavLabel`, `search.ariaLabel`, `search.mobilePlaceholder`).
+
+## Recommendation
+
+File one P1 issue to wire `NewsletterCTA` through `useTranslations('newsletter')` (add 5 missing keys). Bundle the SiteHeader aria-label swap and the latent interaction-mounted components in the same PR — same pattern, ~30 LOC. End-to-end change is a single tight commit.
+
+## Out-of-scope but adjacent
+
+The grep deliberately ignored Storybook files, test files, and admin-shell components (per current scope split). A full sweep including those would likely surface more.

--- a/messages/en.json
+++ b/messages/en.json
@@ -66,7 +66,9 @@
     "sortBy": "Sort by:",
     "sortRelevance": "Relevance",
     "sortDate": "Date (newest first)",
-    "searchInputPlaceholder": "Projects, meetings, documents, and more."
+    "searchInputPlaceholder": "Projects, meetings, documents, and more.",
+    "closeAriaLabel": "Close search",
+    "modalAriaLabel": "Search"
   },
   "filters": {
     "board": "Board",
@@ -152,12 +154,17 @@
   },
   "newsletter": {
     "heading": "Stay Connected",
+    "headingFallback": "Trusted by 3,000+ professionals across Canada",
     "description": "Subscribe to our newsletter for the latest updates on Canadian financial reporting standards.",
     "placeholder": "Enter your email",
+    "emailLabel": "Email address",
     "subscribe": "Subscribe",
+    "subscribing": "Subscribing…",
     "success": "Thank you for subscribing!",
     "error": "Subscription failed. Please try again.",
-    "invalidEmail": "Please enter a valid email address."
+    "unknownError": "Something went wrong. Please try again.",
+    "invalidEmail": "Please enter a valid email address.",
+    "linkedin": "Follow us on LinkedIn"
   },
   "footer": {
     "copyright": "\u00a9 {year} RAS Canada. All rights reserved.",
@@ -212,7 +219,8 @@
     "externalLink": "Opens in a new tab",
     "expandSection": "Expand section",
     "collapseSection": "Collapse section",
-    "switchLanguage": "Switch to {language}"
+    "switchLanguage": "Switch to {language}",
+    "onThisPage": "On this page"
   },
   "errors": {
     "404": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -66,7 +66,9 @@
     "sortBy": "Trier par :",
     "sortRelevance": "Pertinence",
     "sortDate": "Date (plus récent d'abord)",
-    "searchInputPlaceholder": "Projets, réunions, documents et plus."
+    "searchInputPlaceholder": "Projets, réunions, documents et plus.",
+    "closeAriaLabel": "Fermer la recherche",
+    "modalAriaLabel": "Recherche"
   },
   "filters": {
     "board": "Conseil",
@@ -152,12 +154,17 @@
   },
   "newsletter": {
     "heading": "Restez connecté",
+    "headingFallback": "Approuvé par plus de 3 000 professionnels au Canada",
     "description": "Abonnez-vous à notre bulletin pour les dernières mises à jour sur les normes canadiennes d'information financière.",
     "placeholder": "Entrez votre courriel",
+    "emailLabel": "Adresse courriel",
     "subscribe": "S'abonner",
+    "subscribing": "Inscription en cours…",
     "success": "Merci de votre abonnement !",
     "error": "L'abonnement a échoué. Veuillez réessayer.",
-    "invalidEmail": "Veuillez entrer une adresse courriel valide."
+    "unknownError": "Une erreur est survenue. Veuillez réessayer.",
+    "invalidEmail": "Veuillez entrer une adresse courriel valide.",
+    "linkedin": "Suivez-nous sur LinkedIn"
   },
   "footer": {
     "copyright": "© {year} NIFC Canada. Tous droits réservés.",
@@ -212,7 +219,8 @@
     "externalLink": "S'ouvre dans un nouvel onglet",
     "expandSection": "Développer la section",
     "collapseSection": "Réduire la section",
-    "switchLanguage": "Passer à {language}"
+    "switchLanguage": "Passer à {language}",
+    "onThisPage": "Sur cette page"
   },
   "errors": {
     "404": {

--- a/src/components/AnchorNav.tsx
+++ b/src/components/AnchorNav.tsx
@@ -20,6 +20,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
+import { useTranslations } from 'next-intl'
 
 export type AnchorNavItem = {
   label: string
@@ -32,8 +33,10 @@ export type AnchorNavProps = {
 }
 
 export function AnchorNav({ items }: AnchorNavProps) {
+  const t = useTranslations('a11y')
   const [activeId, setActiveId] = useState<string>(items[0]?.id || '')
   const [isExpanded, setIsExpanded] = useState(false)
+  const onThisPage = t('onThisPage')
 
   const handleObserver = useCallback((entries: IntersectionObserverEntry[]) => {
     // Find the first intersecting entry (topmost visible section)
@@ -64,10 +67,10 @@ export function AnchorNav({ items }: AnchorNavProps) {
   }
 
   return (
-    <nav data-testid="anchor-nav" aria-label="On this page">
+    <nav data-testid="anchor-nav" aria-label={onThisPage}>
       {/* Desktop: sticky sidebar */}
       <div className="hidden md:block sticky top-8">
-        <p className="mb-3 text-sm font-semibold text-text-primary">On this page</p>
+        <p className="mb-3 text-sm font-semibold text-text-primary">{onThisPage}</p>
         <hr className="mb-3 border-gray-200" />
         <ul className="space-y-1.5" role="list">
           {items.map((item) => (
@@ -97,7 +100,7 @@ export function AnchorNav({ items }: AnchorNavProps) {
           aria-expanded={isExpanded}
           data-testid="anchor-nav-toggle"
         >
-          <span>On this page</span>
+          <span>{onThisPage}</span>
           <svg
             className={`h-4 w-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
             fill="none"

--- a/src/components/NewsletterCTA.tsx
+++ b/src/components/NewsletterCTA.tsx
@@ -20,34 +20,33 @@
 'use client'
 
 import React, { useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui'
 import { subscribeToNewsletter } from '@/actions/newsletter'
 
 type NewsletterCTAProps = {
-  /** Heading text */
+  /** Heading text. Falls back to `newsletter.headingFallback` translation. */
   heading?: string
   /** Optional description paragraph */
   description?: string
   className?: string
 }
 
-export function NewsletterCTA({
-  heading = 'Trusted by 3,000+ professionals across Canada',
-  description,
-  className = '',
-}: NewsletterCTAProps) {
+export function NewsletterCTA({ heading, description, className = '' }: NewsletterCTAProps) {
+  const t = useTranslations('newsletter')
   const [email, setEmail] = useState('')
   const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle')
   const [errorMessage, setErrorMessage] = useState('')
 
+  const resolvedHeading = heading ?? t('headingFallback')
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
 
-    // Basic email validation
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
     if (!emailRegex.test(email)) {
       setStatus('error')
-      setErrorMessage('Please enter a valid email address.')
+      setErrorMessage(t('invalidEmail'))
       return
     }
 
@@ -64,27 +63,27 @@ export function NewsletterCTA({
       }
     } catch {
       setStatus('error')
-      setErrorMessage('Something went wrong. Please try again.')
+      setErrorMessage(t('unknownError'))
     }
   }
 
   return (
     <div className={`${className}`.trim()} data-testid="newsletter-cta">
-      {heading && (
-        <h2 className="text-2xl font-bold text-text-primary">{heading}</h2>
+      {resolvedHeading && (
+        <h2 className="text-2xl font-bold text-text-primary">{resolvedHeading}</h2>
       )}
 
       {description && <p className="mt-2 text-base text-text-muted">{description}</p>}
 
       {status === 'success' ? (
         <p className="mt-4 text-sm font-medium text-green-700" role="status">
-          Thank you for subscribing!
+          {t('success')}
         </p>
       ) : (
         <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start">
           <div className="flex-1">
             <label htmlFor="newsletter-email" className="sr-only">
-              Email address
+              {t('emailLabel')}
             </label>
             <input
               id="newsletter-email"
@@ -94,7 +93,7 @@ export function NewsletterCTA({
                 setEmail(e.target.value)
                 if (status === 'error') setStatus('idle')
               }}
-              placeholder="Enter your email"
+              placeholder={t('placeholder')}
               required
               className="w-full rounded-sm border border-gray-300 bg-white px-4 py-2.5 text-base text-text-primary placeholder:text-text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary-bright/30"
               aria-invalid={status === 'error'}
@@ -113,12 +112,11 @@ export function NewsletterCTA({
             disabled={status === 'submitting'}
             data-testid="newsletter-submit"
           >
-            {status === 'submitting' ? 'Subscribing...' : 'Subscribe'}
+            {status === 'submitting' ? t('subscribing') : t('subscribe')}
           </Button>
         </form>
       )}
 
-      {/* LinkedIn CTA */}
       <a
         href="https://www.linkedin.com/company/fras-canada"
         target="_blank"
@@ -126,11 +124,10 @@ export function NewsletterCTA({
         className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-primary hover:text-primary-vivid"
         data-testid="newsletter-linkedin"
       >
-        {/* LinkedIn icon */}
         <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
         </svg>
-        Follow us on LinkedIn
+        {t('linkedin')}
       </a>
     </div>
   )

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -28,6 +28,7 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
+import { useTranslations } from 'next-intl'
 import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import { TagChip } from '@/components/TagChip'
 import { Button } from '@/components/ui'
@@ -78,6 +79,8 @@ function saveRecentSearch(query: string): void {
 }
 
 export function SearchModal({ isOpen, onClose, popularTags }: SearchModalProps) {
+  const t = useTranslations('search')
+  const tCommon = useTranslations('common')
   const [query, setQuery] = useState('')
   const [recentSearches, setRecentSearches] = useState<string[]>([])
   const inputRef = useRef<HTMLInputElement>(null)
@@ -175,7 +178,7 @@ export function SearchModal({ isOpen, onClose, popularTags }: SearchModalProps) 
       className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 pt-24 sm:pt-32"
       role="dialog"
       aria-modal="true"
-      aria-label="Search"
+      aria-label={t('modalAriaLabel')}
       data-testid="search-modal"
       onClick={(e) => {
         // Close when clicking backdrop
@@ -193,7 +196,7 @@ export function SearchModal({ isOpen, onClose, popularTags }: SearchModalProps) 
             type="button"
             onClick={onClose}
             className="rounded-sm p-1 text-text-muted hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-bright"
-            aria-label="Close search"
+            aria-label={t('closeAriaLabel')}
             data-testid="search-modal-close"
           >
             <XMarkIcon className="h-6 w-6" aria-hidden="true" />
@@ -214,10 +217,10 @@ export function SearchModal({ isOpen, onClose, popularTags }: SearchModalProps) 
             onKeyDown={(e) => {
               if (e.key === 'Enter') handleSearch()
             }}
-            placeholder="Projects, meetings, documents, and more."
+            placeholder={t('searchInputPlaceholder')}
             className="w-full rounded-sm border border-gray-300 bg-white py-3.5 pl-12 pr-4 text-lg placeholder:text-text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary-bright/30"
             data-testid="search-modal-input"
-            aria-label="Search query"
+            aria-label={t('queryLabel')}
           />
         </div>
 
@@ -226,7 +229,7 @@ export function SearchModal({ isOpen, onClose, popularTags }: SearchModalProps) 
           {/* Recent searches */}
           {recentSearches.length > 0 && (
             <div data-testid="search-modal-recent">
-              <h3 className="mb-3 text-sm font-semibold text-text-heading">Recent</h3>
+              <h3 className="mb-3 text-sm font-semibold text-text-heading">{t('recentSearches')}</h3>
               <div className="flex flex-wrap gap-2">
                 {recentSearches.map((term) => (
                   <TagChip
@@ -242,7 +245,7 @@ export function SearchModal({ isOpen, onClose, popularTags }: SearchModalProps) 
           {/* Popular tags from CMS */}
           {popularTags && popularTags.length > 0 && (
             <div data-testid="search-modal-popular">
-              <h3 className="mb-3 text-sm font-semibold text-text-heading">Popular</h3>
+              <h3 className="mb-3 text-sm font-semibold text-text-heading">{t('popularTags')}</h3>
               <div className="flex flex-wrap gap-2">
                 {popularTags.map((tag) => (
                   <TagChip
@@ -264,7 +267,7 @@ export function SearchModal({ isOpen, onClose, popularTags }: SearchModalProps) 
             onClick={onClose}
             data-testid="search-modal-cancel"
           >
-            Cancel
+            {tCommon('cancel')}
           </Button>
           <Button
             variant="dark"
@@ -273,7 +276,7 @@ export function SearchModal({ isOpen, onClose, popularTags }: SearchModalProps) 
             disabled={!query.trim()}
             data-testid="search-modal-submit"
           >
-            Search
+            {t('searchButton')}
           </Button>
         </div>
       </div>

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -25,6 +25,7 @@
 'use client'
 
 import React from 'react'
+import { useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 import { LanguageSwitcher } from './LanguageSwitcher'
 import {
@@ -94,6 +95,8 @@ function buildStaticLinks(navigation: Navigation | null | undefined): { label: s
 }
 
 export function MobileMenu({ isOpen, onClose, navigation }: MobileMenuProps) {
+  const tNav = useTranslations('nav')
+  const tSearch = useTranslations('search')
   const navSections = buildNavSections(navigation)
   const staticLinks = buildStaticLinks(navigation)
 
@@ -109,12 +112,12 @@ export function MobileMenu({ isOpen, onClose, navigation }: MobileMenuProps) {
         >
           {/* Header: close button */}
           <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
-            <span className="text-lg font-semibold text-text-primary">Menu</span>
+            <span className="text-lg font-semibold text-text-primary">{tNav('menu')}</span>
             <button
               type="button"
               onClick={onClose}
               className="rounded-sm p-1 text-text-muted hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-bright cursor-pointer"
-              aria-label="Close menu"
+              aria-label={tNav('closeMenu')}
               data-testid="mobile-menu-close"
             >
               <XMarkIcon className="h-6 w-6" aria-hidden="true" />
@@ -130,7 +133,7 @@ export function MobileMenu({ isOpen, onClose, navigation }: MobileMenuProps) {
               />
               <input
                 type="search"
-                placeholder="Search projects, standards..."
+                placeholder={tSearch('mobilePlaceholder')}
                 className="w-full rounded-sm border border-gray-300 bg-white py-2.5 pl-10 pr-4 text-sm placeholder:text-text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary-bright/30"
                 data-testid="mobile-menu-search"
               />
@@ -147,7 +150,7 @@ export function MobileMenu({ isOpen, onClose, navigation }: MobileMenuProps) {
           </div>
 
           {/* Navigation sections */}
-          <nav className="px-6 py-4" aria-label="Mobile navigation">
+          <nav className="px-6 py-4" aria-label={tNav('mobileNavLabel')}>
             {navSections.length > 0 && (
               <div className="space-y-1">
                 {navSections.map((section) => (

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -201,7 +201,7 @@ export function SiteHeader({ navigation, popularTags }: SiteHeaderProps) {
       {primaryNav.length > 0 && (
         <div className="hidden lg:block border-t border-gray-200" data-testid="primary-nav">
           <Container>
-            <nav className="flex items-center gap-6 py-3" aria-label="Primary navigation">
+            <nav className="flex items-center gap-6 py-3" aria-label={tNav('primaryNavLabel')}>
               {primaryNav.map((item, i) => {
                 const hasMegaMenu = megaMenu.some((m) => m.trigger_label === item.label)
 


### PR DESCRIPTION
## Summary
- Closes #228
- Stacked on PR #227 (#215 fr.json fix) — merge that first
- Follow-up to #215: even with fr.json corrected, 5 components rendered hardcoded English on /fr because they bypassed next-intl entirely

## What changed

| Component | Strings | Notes |
|---|---|---|
| `NewsletterCTA.tsx` | 8 | Footer-mounted → every public page. Most visible bug. |
| `SiteHeader.tsx` | 1 | `aria-label="Primary navigation"` → `t('primaryNavLabel')` |
| `SearchModal.tsx` | 8 | aria-labels, placeholder, "Recent"/"Popular" headings, Cancel/Search buttons |
| `MobileMenu.tsx` | 4 | Menu label, close aria, search placeholder, nav aria |
| `AnchorNav.tsx` | 2 | "On this page" heading + aria-label |

8 new translation keys (en.json + fr.json):
- `newsletter.headingFallback`, `.emailLabel`, `.subscribing`, `.unknownError`, `.linkedin`
- `search.closeAriaLabel`, `.modalAriaLabel`
- `a11y.onThisPage`

## Validation
- [x] `npx tsc --noEmit` — clean
- [x] `vitest run i18n-parity.test.ts` — 4/4 pass
- [x] JSDOM scan on `/fr`, `/fr/recherche`, `/fr/projets-actifs`, `/fr/nous-joindre`, `/fr/consultations-ouvertes` — **0 English markers** (was 2 per page)
- [x] Audit report at `.ai-reports/i18n-coverage-audit-2026-05-04.md` documents method + findings

## Test plan
- [ ] Visual QA on `/fr` footer — newsletter signup renders FR labels and button copy
- [ ] Open SearchModal on `/fr` — modal aria-label, placeholder, Recent/Popular sections in FR
- [ ] Open MobileMenu on `/fr` viewport — close button + search placeholder in FR
- [ ] Visit a `/fr/<board>/about/committees` page (if AnchorNav appears) — sidebar heading reads "Sur cette page"

🤖 Generated with [Claude Code](https://claude.com/claude-code)