### PR TITLE
fix(search): client bundle now reads NEXT_PUBLIC_SEARCH_PROVIDER

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,12 @@ NEXT_PUBLIC_BUILD_TIME=
 # Values: `meilisearch` (default) | `algolia`
 # Leave unset for the default. Flip to `algolia` to opt into the Slice 2
 # adapter — requires the ALGOLIA_* keys below to be populated.
+#
+# Set BOTH vars to the same value — server reads SEARCH_PROVIDER, client
+# bundles only see NEXT_PUBLIC_SEARCH_PROVIDER. Drift causes write/read
+# providers to disagree.
 SEARCH_PROVIDER=
+NEXT_PUBLIC_SEARCH_PROVIDER=
 
 # Dual-write parallel-indexing window (#176 / Algolia migration Slice 5).
 # Set to `true` to fan out every Payload write to BOTH Meilisearch +

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -19,7 +19,6 @@ import { algoliaProvider } from './algolia'
 import { buildDualWriteProvider, isDualWriteEnabled } from './dual-write'
 import { meilisearchProvider } from './meilisearch'
 import {
-  SEARCH_PROVIDER_ENV,
   type SearchProvider,
   type SearchProviderName,
 } from './types'
@@ -29,7 +28,12 @@ import {
 const cache = new Map<SearchProviderName, SearchProvider>()
 
 function resolveProviderName(): SearchProviderName {
-  const raw = process.env[SEARCH_PROVIDER_ENV]?.toLowerCase().trim()
+  // Server reads SEARCH_PROVIDER; client bundles only see NEXT_PUBLIC_*.
+  // Both keys must be referenced via LITERAL property access — Next.js only
+  // inlines `process.env.NEXT_PUBLIC_X` at build time, not `process.env[var]`.
+  const raw = (process.env.SEARCH_PROVIDER ?? process.env.NEXT_PUBLIC_SEARCH_PROVIDER)
+    ?.toLowerCase()
+    .trim()
   if (raw === 'algolia') return 'algolia'
   return 'meilisearch'
 }

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -81,8 +81,12 @@ export interface SearchProvider {
   applySettings(indexName: string, settings: IndexSettings): Promise<void>
 }
 
-/** Env-var key that selects the provider. Default: `meilisearch`. */
+/** Env-var key that selects the provider on the server. Default: `meilisearch`. */
 export const SEARCH_PROVIDER_ENV = 'SEARCH_PROVIDER'
+
+/** Same selector for client components (Next.js only inlines NEXT_PUBLIC_* into
+    client bundles). Must match SEARCH_PROVIDER server-side or reads/writes drift. */
+export const SEARCH_PROVIDER_PUBLIC_ENV = 'NEXT_PUBLIC_SEARCH_PROVIDER'
 
 /** Allowed values for `SEARCH_PROVIDER`. */
 export type SearchProviderName = SearchProvider['name']


### PR DESCRIPTION
## Summary
Latent bug from Slice 1 (#172). `getSearchProvider()` read `process.env.SEARCH_PROVIDER` only — server-only in Next.js. Client bundles silently fell back to meilisearch regardless of \`.env\`, so the frontend always hit Meilisearch even with \`SEARCH_PROVIDER=algolia\` set.

Symptom: SSR'd Algolia results render fine, then on hydration the client throws \`MeiliSearchApiError: The Authorization header is missing\` on every interaction. Discovered driving the Slice 2 / #173 POC live for the first time.

## Fix
- Factory reads \`process.env.SEARCH_PROVIDER ?? process.env.NEXT_PUBLIC_SEARCH_PROVIDER\` via **literal** property access — bracket access (\`process.env[VAR]\`) does NOT get statically inlined by Next/Turbopack.
- \`.env.example\` documents both vars side-by-side with a "must stay in sync" warning.

## Validation
- [x] \`npx tsc --noEmit\` clean
- [x] \`vitest run src/search/__tests__\` — 28/28 pass
- [x] Bundle inspection confirms inlining (algolia chunk has appId + searchKey baked in)
- [x] Live: \`/en/search?q=standards\` returns 11 real news hits from Algolia, zero \`MeiliSearchApiError\`

## Action required for any environment running Algolia
Add \`NEXT_PUBLIC_SEARCH_PROVIDER\` to \`.env\` (must match \`SEARCH_PROVIDER\`) and restart \`next dev\` — NEXT_PUBLIC_* envs are bundle-time constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)