### PR TITLE
fix(i18n): sweep FR chrome bleeds (5 dogfood findings)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -68,7 +68,25 @@
     "sortDate": "Date (newest first)",
     "searchInputPlaceholder": "Projects, meetings, documents, and more.",
     "closeAriaLabel": "Close search",
-    "modalAriaLabel": "Search"
+    "modalAriaLabel": "Search",
+    "readMore": "Read More",
+    "viewDocument": "View Document",
+    "viewMore": "View More",
+    "watchRecording": "Watch Recording",
+    "readSummary": "Read Summary",
+    "viewDetails": "View Details",
+    "downloadGuide": "Download Guide",
+    "contentTypes": {
+      "standard": "Standard",
+      "news": "News",
+      "webinar": "Webinar",
+      "meeting": "Meeting Summary",
+      "guidance": "Guidance",
+      "consultation": "Document for Comment",
+      "decision": "Decision Summary",
+      "deadline": "Deadline",
+      "resource": "Resource"
+    }
   },
   "filters": {
     "board": "Board",
@@ -107,7 +125,36 @@
     "keyProposals": "Key Proposals",
     "contacts": "Contacts",
     "relatedDocuments": "Related Documents",
-    "stage": "Stage"
+    "stage": "Stage",
+    "stageLabel": "Stage {n}: {name}",
+    "badges": {
+      "exposureDraft": "Exposure Draft",
+      "publicComment": "Public Comment",
+      "survey": "Survey",
+      "research": "Research",
+      "reExposureDraft": "Re-exposure Draft"
+    }
+  },
+  "listings": {
+    "sortBy": "Sort By",
+    "itemsPerPage": "Items Per Page",
+    "type": "Type",
+    "startDate": "Start Date",
+    "endDate": "End Date",
+    "allItems": "All Items",
+    "loading": "Loading…",
+    "noItems": "No items found",
+    "noNews": "No news items found",
+    "noResources": "No resources found",
+    "sortNewest": "Publication date: Newest",
+    "sortOldest": "Publication date: Oldest",
+    "newsCategories": {
+      "documentForComment": "Document for Comment",
+      "internationalActivity": "International Activity",
+      "meetingSummary": "Meeting Summary",
+      "news": "News",
+      "resource": "Resource"
+    }
   },
   "consultations": {
     "title": "Open Consultations",
@@ -123,6 +170,13 @@
     "title": "Boards",
     "overview": "Overview",
     "boardDetail": "{board} — RAS Canada",
+    "abbreviations": {
+      "acsb": "AcSB",
+      "psab": "PSAB",
+      "aasb": "AASB",
+      "cssb": "CSSB",
+      "rasoc": "RASOC"
+    },
     "quickActions": "Quick Actions",
     "upcomingEvents": "Upcoming Events",
     "resources": "Resources",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -68,7 +68,25 @@
     "sortDate": "Date (plus récent d'abord)",
     "searchInputPlaceholder": "Projets, réunions, documents et plus.",
     "closeAriaLabel": "Fermer la recherche",
-    "modalAriaLabel": "Recherche"
+    "modalAriaLabel": "Recherche",
+    "readMore": "Lire la suite",
+    "viewDocument": "Voir le document",
+    "viewMore": "Voir plus",
+    "watchRecording": "Visionner l'enregistrement",
+    "readSummary": "Lire le résumé",
+    "viewDetails": "Voir les détails",
+    "downloadGuide": "Télécharger le guide",
+    "contentTypes": {
+      "standard": "Norme",
+      "news": "Nouvelles",
+      "webinar": "Webinaire",
+      "meeting": "Résumé de réunion",
+      "guidance": "Guide d'application",
+      "consultation": "Document à commenter",
+      "decision": "Résumé des décisions",
+      "deadline": "Date limite",
+      "resource": "Ressource"
+    }
   },
   "filters": {
     "board": "Conseil",
@@ -107,7 +125,36 @@
     "keyProposals": "Propositions clés",
     "contacts": "Personnes-ressources",
     "relatedDocuments": "Documents connexes",
-    "stage": "Étape"
+    "stage": "Étape",
+    "stageLabel": "Étape {n} : {name}",
+    "badges": {
+      "exposureDraft": "Exposé-sondage",
+      "publicComment": "Commentaires du public",
+      "survey": "Sondage",
+      "research": "Recherche",
+      "reExposureDraft": "Réexposé-sondage"
+    }
+  },
+  "listings": {
+    "sortBy": "Trier par",
+    "itemsPerPage": "Éléments par page",
+    "type": "Type",
+    "startDate": "Date de début",
+    "endDate": "Date de fin",
+    "allItems": "Tous les éléments",
+    "loading": "Chargement…",
+    "noItems": "Aucun élément trouvé",
+    "noNews": "Aucune nouvelle trouvée",
+    "noResources": "Aucune ressource trouvée",
+    "sortNewest": "Date de publication : plus récent",
+    "sortOldest": "Date de publication : plus ancien",
+    "newsCategories": {
+      "documentForComment": "Document à commenter",
+      "internationalActivity": "Activité internationale",
+      "meetingSummary": "Résumé de réunion",
+      "news": "Nouvelles",
+      "resource": "Ressource"
+    }
   },
   "consultations": {
     "title": "Consultations ouvertes",
@@ -123,6 +170,13 @@
     "title": "Conseils",
     "overview": "Aperçu",
     "boardDetail": "{board} — NIFC Canada",
+    "abbreviations": {
+      "acsb": "CNC",
+      "psab": "CCSP",
+      "aasb": "CNAC",
+      "cssb": "CCNID",
+      "rasoc": "CSNIC"
+    },
     "quickActions": "Actions rapides",
     "upcomingEvents": "Événements à venir",
     "resources": "Ressources",

--- a/src/app/(frontend)/[locale]/(frontend)/[board]/resources/ResourcesListingClient.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/[board]/resources/ResourcesListingClient.tsx
@@ -14,7 +14,8 @@
  */
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useTranslations } from 'next-intl'
 import { CategoryPills } from '@/components/CategoryPills'
 import { SortFilterBar } from '@/components/SortFilterBar'
 import { ListingItem } from '@/components/ListingItem'
@@ -35,6 +36,11 @@ type ResourcesListingClientProps = {
   standardSlug: string
 }
 
+/** Resource-specific categories. The English value is what the API
+    filters by; only the displayed label is localized at render. The
+    `Article` / `Guidance` / `In Brief` / `Other` / `Webinar` strings
+    aren't yet covered by the dictionary — falls back to the English
+    label until they're added (separate follow-up). */
 const CATEGORY_OPTIONS = [
   'All Items', 'Article', 'Guidance', 'In Brief', 'Other', 'Webinar',
 ]
@@ -48,19 +54,8 @@ const TYPE_OPTIONS = [
   { label: 'Webpage', value: 'Webpage' },
 ]
 
-const SORT_OPTIONS = [
-  { label: 'Publication date: Newest', value: 'newest' },
-  { label: 'Publication date: Oldest', value: 'oldest' },
-]
-
-const ITEMS_PER_PAGE_OPTIONS = [
-  { label: '10', value: '10' },
-  { label: '20', value: '20' },
-  { label: '30', value: '30' },
-  { label: 'All', value: 'all' },
-]
-
 export function ResourcesListingClient({ standardSlug }: ResourcesListingClientProps) {
+  const t = useTranslations('listings')
   const [category, setCategory] = useState('')
   const [sort, setSort] = useState('newest')
   const [itemsPerPage, setItemsPerPage] = useState('10')
@@ -71,6 +66,24 @@ export function ResourcesListingClient({ standardSlug }: ResourcesListingClientP
   const [docs, setDocs] = useState<ResourceDoc[]>([])
   const [totalDocs, setTotalDocs] = useState(0)
   const [loading, setLoading] = useState(true)
+
+  const sortOptions = useMemo(
+    () => [
+      { label: t('sortNewest'), value: 'newest' },
+      { label: t('sortOldest'), value: 'oldest' },
+    ],
+    [t],
+  )
+
+  const itemsPerPageOptions = useMemo(
+    () => [
+      { label: '10', value: '10' },
+      { label: '20', value: '20' },
+      { label: '30', value: '30' },
+      { label: t('allItems'), value: 'all' },
+    ],
+    [t],
+  )
 
   const fetchData = useCallback(async () => {
     setLoading(true)
@@ -110,7 +123,7 @@ export function ResourcesListingClient({ standardSlug }: ResourcesListingClientP
   }, [category, sort, itemsPerPage, typeFilter, startDate, endDate])
 
   const categoryPillOptions = CATEGORY_OPTIONS.map((cat) => ({
-    label: cat,
+    label: cat === 'All Items' ? t('allItems') : cat,
     value: cat === 'All Items' ? '' : cat,
     isActive: cat === 'All Items' ? category === '' : category === cat,
   }))
@@ -128,10 +141,10 @@ export function ResourcesListingClient({ standardSlug }: ResourcesListingClientP
       {/* Sort/filter bar */}
       <SortFilterBar
         className="mt-4"
-        sortOptions={SORT_OPTIONS}
+        sortOptions={sortOptions}
         sortValue={sort}
         onSortChange={setSort}
-        itemsPerPageOptions={ITEMS_PER_PAGE_OPTIONS}
+        itemsPerPageOptions={itemsPerPageOptions}
         itemsPerPageValue={itemsPerPage}
         onItemsPerPageChange={setItemsPerPage}
         typeFilterOptions={TYPE_OPTIONS}
@@ -146,9 +159,9 @@ export function ResourcesListingClient({ standardSlug }: ResourcesListingClientP
       {/* Results */}
       <div className="mt-6" data-testid="section-listing-results">
         {loading ? (
-          <div className="py-8 text-center text-text-muted">Loading resources...</div>
+          <div className="py-8 text-center text-text-muted">{t('loading')}</div>
         ) : docs.length === 0 ? (
-          <div className="py-8 text-center text-text-muted">No resources found</div>
+          <div className="py-8 text-center text-text-muted">{t('noResources')}</div>
         ) : (
           <div className="space-y-0">
             {docs.map((doc) => (

--- a/src/app/(frontend)/[locale]/(frontend)/news-listings/NewsListingClient.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/news-listings/NewsListingClient.tsx
@@ -18,7 +18,8 @@
  */
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useTranslations } from 'next-intl'
 import { CategoryPills } from '@/components/CategoryPills'
 import { SortFilterBar } from '@/components/SortFilterBar'
 import { ListingItem } from '@/components/ListingItem'
@@ -43,25 +44,25 @@ type NewsListingClientProps = {
   isVolunteerMode?: boolean
 }
 
-const NEWS_CATEGORIES = [
-  'All Items', 'Document for Comment', 'International Activity', 'Meeting Summary', 'News', 'Resource',
+/** Category id → translation key under listings.newsCategories.
+    Display labels are pulled at render time so locale changes don't
+    require remounting. The category VALUE sent to the API matches the
+    raw English string the news collection is filtered by — only the
+    label is localized. */
+const NEWS_CATEGORY_DEFS: ReadonlyArray<{ id: string; apiValue: string }> = [
+  { id: 'allItems', apiValue: '' },
+  { id: 'documentForComment', apiValue: 'Document for Comment' },
+  { id: 'internationalActivity', apiValue: 'International Activity' },
+  { id: 'meetingSummary', apiValue: 'Meeting Summary' },
+  { id: 'news', apiValue: 'News' },
+  { id: 'resource', apiValue: 'Resource' },
 ]
 
 const BOARD_TABS = ['AASB', 'CSSB', 'PSAB', 'RASOC', 'AcSB']
 
-const SORT_OPTIONS = [
-  { label: 'Publication date: Newest', value: 'newest' },
-  { label: 'Publication date: Oldest', value: 'oldest' },
-]
-
-const ITEMS_PER_PAGE_OPTIONS = [
-  { label: '10', value: '10' },
-  { label: '20', value: '20' },
-  { label: '30', value: '30' },
-  { label: 'All', value: 'all' },
-]
-
 export function NewsListingClient({ boardSlug, isVolunteerMode }: NewsListingClientProps) {
+  const tListings = useTranslations('listings')
+  const tCategories = useTranslations('listings.newsCategories')
   const [category, setCategory] = useState('')
   const [volunteerBoard, setVolunteerBoard] = useState(BOARD_TABS[0].toLowerCase())
   const [sort, setSort] = useState('newest')
@@ -72,6 +73,24 @@ export function NewsListingClient({ boardSlug, isVolunteerMode }: NewsListingCli
   const [docs, setDocs] = useState<NewsDoc[]>([])
   const [totalDocs, setTotalDocs] = useState(0)
   const [loading, setLoading] = useState(true)
+
+  const sortOptions = useMemo(
+    () => [
+      { label: tListings('sortNewest'), value: 'newest' },
+      { label: tListings('sortOldest'), value: 'oldest' },
+    ],
+    [tListings],
+  )
+
+  const itemsPerPageOptions = useMemo(
+    () => [
+      { label: '10', value: '10' },
+      { label: '20', value: '20' },
+      { label: '30', value: '30' },
+      { label: tListings('allItems'), value: 'all' },
+    ],
+    [tListings],
+  )
 
   const fetchData = useCallback(async () => {
     setLoading(true)
@@ -134,10 +153,10 @@ export function NewsListingClient({ boardSlug, isVolunteerMode }: NewsListingCli
         />
       ) : (
         <CategoryPills
-          options={NEWS_CATEGORIES.map((cat) => ({
-            label: cat,
-            value: cat === 'All Items' ? '' : cat,
-            isActive: cat === 'All Items' ? category === '' : category === cat,
+          options={NEWS_CATEGORY_DEFS.map((def) => ({
+            label: def.id === 'allItems' ? tListings('allItems') : tCategories(def.id),
+            value: def.apiValue,
+            isActive: def.apiValue === '' ? category === '' : category === def.apiValue,
           }))}
           onChange={setCategory}
         />
@@ -146,10 +165,10 @@ export function NewsListingClient({ boardSlug, isVolunteerMode }: NewsListingCli
       {/* Sort/filter bar */}
       <SortFilterBar
         className="mt-4"
-        sortOptions={SORT_OPTIONS}
+        sortOptions={sortOptions}
         sortValue={sort}
         onSortChange={setSort}
-        itemsPerPageOptions={ITEMS_PER_PAGE_OPTIONS}
+        itemsPerPageOptions={itemsPerPageOptions}
         itemsPerPageValue={itemsPerPage}
         onItemsPerPageChange={setItemsPerPage}
         showDateRange
@@ -161,9 +180,9 @@ export function NewsListingClient({ boardSlug, isVolunteerMode }: NewsListingCli
       {/* Results */}
       <div className="mt-6" data-testid="section-listing-results">
         {loading ? (
-          <div className="py-8 text-center text-text-muted">Loading news...</div>
+          <div className="py-8 text-center text-text-muted">{tListings('loading')}</div>
         ) : docs.length === 0 ? (
-          <div className="py-8 text-center text-text-muted">No news items found</div>
+          <div className="py-8 text-center text-text-muted">{tListings('noNews')}</div>
         ) : (
           <div className="space-y-0">
             {docs.map((doc) => (

--- a/src/app/(frontend)/[locale]/(frontend)/news-listings/page.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/news-listings/page.tsx
@@ -17,20 +17,35 @@
  * - Volunteer variant is a separate concern (see acceptance criteria)
  */
 import type { Metadata } from 'next'
+import { getTranslations } from 'next-intl/server'
 import { PageHeader } from '@/components/PageHeader'
 import { NewsListingClient } from './NewsListingClient'
 
-export const metadata: Metadata = {
-  title: 'News — RAS Canada',
-  description: 'Browse the latest news, meeting summaries, and announcements.',
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const t = await getTranslations({ locale, namespace: 'news' })
+  return {
+    title: `${t('title')} — RAS Canada`,
+    description: t('latestNews'),
+  }
 }
 
 export const revalidate = 60
 
-export default function NewsListingPage() {
+export default async function NewsListingPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const t = await getTranslations({ locale, namespace: 'news' })
   return (
     <div className="mx-auto max-w-[1440px] px-4 py-8 sm:px-6 lg:px-8" data-testid="page-news-listing">
-      <PageHeader title="News" />
+      <PageHeader title={t('title')} />
       <NewsListingClient />
     </div>
   )

--- a/src/app/(frontend)/[locale]/(frontend)/search/SearchPageClient.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/search/SearchPageClient.tsx
@@ -82,11 +82,12 @@ function inferContentType(
   return 'news'
 }
 
-/** Format a date string for display */
-function formatDate(dateStr: unknown): string {
+/** Format a date string for display in the active locale. */
+function formatDate(dateStr: unknown, locale: string): string {
   if (!dateStr || typeof dateStr !== 'string') return ''
   try {
-    return new Date(dateStr).toLocaleDateString('en-CA', {
+    const intlLocale = locale === 'fr' ? 'fr-CA' : 'en-CA'
+    return new Date(dateStr).toLocaleDateString(intlLocale, {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
@@ -190,6 +191,7 @@ function SortControl() {
 /** Hits list rendering */
 function HitsList() {
   const t = useTranslations('search')
+  const locale = useLocale()
   const { hits } = useHits()
 
   if (hits.length === 0) {
@@ -210,7 +212,7 @@ function HitsList() {
             key={hit.objectID}
             contentType={inferContentType(hitData)}
             board={(hitData.board as string) || ''}
-            date={formatDate(hitData.date || hitData.updatedAt)}
+            date={formatDate(hitData.date || hitData.updatedAt, locale)}
             title={(hitData.title as string) || 'Untitled'}
             href={`/${hitData.slug || hit.objectID}`}
             description={(hitData.summary as string) || (hitData.body as string)?.slice(0, 200) || ''}

--- a/src/components/SearchResultCard.tsx
+++ b/src/components/SearchResultCard.tsx
@@ -23,6 +23,7 @@
  * - Description is truncated with line-clamp-2
  */
 import React from 'react'
+import { useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 import { Badge } from '@/components/ui'
 
@@ -59,30 +60,19 @@ type SearchResultCardProps = {
   className?: string
 }
 
-/** Maps content type to CTA link text */
-const ctaTextMap: Record<ContentType, string> = {
-  standard: 'View Document',
-  news: 'Read More',
-  webinar: 'Watch Recording',
-  meeting: 'Read Summary',
-  guidance: 'View Document',
-  consultation: 'View Document',
-  decision: 'Read Summary',
-  deadline: 'View Details',
-  resource: 'Download Guide',
-}
-
-/** Maps content type to a human-readable badge label */
-const badgeLabelMap: Record<ContentType, string> = {
-  standard: 'Standard',
-  news: 'News',
-  webinar: 'Webinar',
-  meeting: 'Meeting Summary',
-  guidance: 'Guidance',
-  consultation: 'Document for Comment',
-  decision: 'Decision Summary',
-  deadline: 'Deadline',
-  resource: 'Resource',
+/** Maps content type to the translation KEY under `search.*` for the
+    CTA link text. Translations live in messages/{en,fr}.json — no
+    English literals here. */
+const ctaKeyMap: Record<ContentType, string> = {
+  standard: 'viewDocument',
+  news: 'readMore',
+  webinar: 'watchRecording',
+  meeting: 'readSummary',
+  guidance: 'viewDocument',
+  consultation: 'viewDocument',
+  decision: 'readSummary',
+  deadline: 'viewDetails',
+  resource: 'downloadGuide',
 }
 
 export function SearchResultCard({
@@ -97,8 +87,9 @@ export function SearchResultCard({
   fileSize,
   className = '',
 }: SearchResultCardProps) {
-  const ctaText = ctaTextMap[contentType] || 'Read More'
-  const displayBadge = badgeLabel || badgeLabelMap[contentType] || contentType
+  const t = useTranslations('search')
+  const ctaText = t(ctaKeyMap[contentType] || 'readMore')
+  const displayBadge = badgeLabel || t(`contentTypes.${contentType}`)
 
   return (
     <article

--- a/src/components/SortFilterBar.tsx
+++ b/src/components/SortFilterBar.tsx
@@ -19,6 +19,8 @@
  */
 'use client'
 
+import { useTranslations } from 'next-intl'
+
 type SelectOption = {
   label: string
   value: string
@@ -70,6 +72,7 @@ export function SortFilterBar({
   onDateRangeChange,
   className = '',
 }: SortFilterBarProps) {
+  const t = useTranslations('listings')
   return (
     <div
       className={`flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end ${className}`.trim()}
@@ -78,7 +81,7 @@ export function SortFilterBar({
       {/* Sort By */}
       <div className="flex flex-col gap-1">
         <label htmlFor="sort-by" className="text-xs font-semibold uppercase tracking-wide text-text-muted">
-          Sort By
+          {t('sortBy')}
         </label>
         <select
           id="sort-by"
@@ -98,7 +101,7 @@ export function SortFilterBar({
       {/* Items Per Page */}
       <div className="flex flex-col gap-1">
         <label htmlFor="items-per-page" className="text-xs font-semibold uppercase tracking-wide text-text-muted">
-          Items Per Page
+          {t('itemsPerPage')}
         </label>
         <select
           id="items-per-page"
@@ -119,7 +122,7 @@ export function SortFilterBar({
       {typeFilterOptions && onTypeFilterChange && (
         <div className="flex flex-col gap-1">
           <label htmlFor="type-filter" className="text-xs font-semibold uppercase tracking-wide text-text-muted">
-            Type
+            {t('type')}
           </label>
           <select
             id="type-filter"
@@ -142,7 +145,7 @@ export function SortFilterBar({
         <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:gap-2">
           <div className="flex flex-col gap-1">
             <label htmlFor="start-date" className="text-xs font-semibold uppercase tracking-wide text-text-muted">
-              Start Date
+              {t('startDate')}
             </label>
             <input
               id="start-date"
@@ -155,7 +158,7 @@ export function SortFilterBar({
           </div>
           <div className="flex flex-col gap-1">
             <label htmlFor="end-date" className="text-xs font-semibold uppercase tracking-wide text-text-muted">
-              End Date
+              {t('endDate')}
             </label>
             <input
               id="end-date"

--- a/src/components/board/BoardLanding.tsx
+++ b/src/components/board/BoardLanding.tsx
@@ -91,9 +91,22 @@ export async function BoardLanding({ board, locale }: BoardLandingProps) {
     .filter((p) => (p as unknown as { status?: string }).status !== 'closed')
     .slice(0, 5)
 
+  // Boards collection's `abbreviation` field is NOT localized — it always
+  // returns the EN value ("AcSB"). For per-locale display we look up the
+  // localized equivalent ("CNC") via `boards.abbreviations.<key>` keyed on
+  // the lowercase EN abbreviation. The set of boards is closed (5) so the
+  // safe-key list is enumerated in code rather than discovered at runtime.
+  const KNOWN_BOARDS = new Set(['acsb', 'psab', 'aasb', 'cssb', 'rasoc'])
+  const abbrKey = (board.abbreviation || '').toLowerCase()
+  const localizedAbbreviation = KNOWN_BOARDS.has(abbrKey)
+    ? tBoards(`abbreviations.${abbrKey}`)
+    : board.abbreviation || board.name
+
+  // Breadcrumb prepends its own localized Home crumb — we only pass the
+  // board entry (the Breadcrumb component strips a literal `'Home'` first
+  // entry for legacy callers, but a localized entry would double-render).
   const breadcrumbItems = [
-    { label: 'Home', href: '/' },
-    { label: board.abbreviation || board.name, href: `/${board.slug}` },
+    { label: localizedAbbreviation, href: `/${board.slug}` },
   ]
 
   const tabs = (board.tabs || []).filter(
@@ -115,7 +128,7 @@ export async function BoardLanding({ board, locale }: BoardLandingProps) {
         data-board-accent={board.slug}
       >
         <h1 className={`text-3xl font-bold ${accent.heading} md:text-4xl`}>
-          {board.abbreviation ? `${board.abbreviation} — ${board.name}` : board.name}
+          {board.abbreviation ? `${localizedAbbreviation} — ${board.name}` : board.name}
         </h1>
         {board.description && (
           <p className="mt-3 max-w-3xl text-lg text-text-muted">{board.description}</p>
@@ -221,6 +234,7 @@ export async function BoardLanding({ board, locale }: BoardLandingProps) {
           {quickActions.length > 0 && (
             <div className="rounded-md border border-surface-card-border bg-surface-card p-4 shadow-card">
               <QuickActions
+                heading={tBoards('quickActions')}
                 actions={quickActions.map((a) => ({
                   label: a.label,
                   url: a.url,

--- a/src/components/board/ProjectCard.tsx
+++ b/src/components/board/ProjectCard.tsx
@@ -19,12 +19,24 @@
  * - Board slug needed for constructing detail URL: /active-projects/[board]/[project-slug]
  */
 import React from 'react'
+import { useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 import { Badge } from '@/components/ui/Badge'
 
 type ProjectBadge = {
   badge_type?: string | null
   id?: string | null
+}
+
+/** Map English badge_type strings (the underlying enum value) to the
+    translation key under `projects.badges`. The value stays in EN for
+    API/database consistency; only the label is localized at render. */
+const BADGE_TYPE_TO_KEY: Record<string, string> = {
+  'Exposure Draft': 'exposureDraft',
+  'Public Comment': 'publicComment',
+  Survey: 'survey',
+  Research: 'research',
+  'Re-exposure Draft': 'reExposureDraft',
 }
 
 type ProjectCTA = {
@@ -67,7 +79,13 @@ function badgeTypeToVariant(
 }
 
 export function ProjectCard({ project, className = '' }: ProjectCardProps) {
+  const t = useTranslations('projects')
   const detailUrl = `/active-projects/${project.boardSlug}/${project.slug}`
+
+  function badgeLabel(badgeType: string): string {
+    const key = BADGE_TYPE_TO_KEY[badgeType]
+    return key ? t(`badges.${key}`) : badgeType
+  }
 
   return (
     <article
@@ -90,7 +108,7 @@ export function ProjectCard({ project, className = '' }: ProjectCardProps) {
           {project.badges.map((badge, i) => (
             badge.badge_type && (
               <Badge key={badge.id || i} variant={badgeTypeToVariant(badge.badge_type)}>
-                {badge.badge_type}
+                {badgeLabel(badge.badge_type)}
               </Badge>
             )
           ))}
@@ -111,7 +129,7 @@ export function ProjectCard({ project, className = '' }: ProjectCardProps) {
             {project.currentStage}
           </span>
           <span className="text-sm font-medium text-text-heading">
-            Stage {project.currentStage}: {project.currentStageName}
+            {t('stageLabel', { n: project.currentStage, name: project.currentStageName })}
           </span>
         </div>
       )}

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -97,6 +97,7 @@ function buildFlatMenuItems(
 export function SiteHeader({ navigation, popularTags }: SiteHeaderProps) {
   const tSearch = useTranslations('search')
   const tNav = useTranslations('nav')
+  const tCommon = useTranslations('common')
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [searchModalOpen, setSearchModalOpen] = useState(false)
 
@@ -152,7 +153,7 @@ export function SiteHeader({ navigation, popularTags }: SiteHeaderProps) {
       <Container>
         <div className="flex items-center justify-between gap-4 py-4">
           <Link href="/" className="flex-shrink-0" data-testid="site-logo">
-            <span className="text-xl font-bold text-primary">RAS Canada</span>
+            <span className="text-xl font-bold text-primary">{tCommon('siteName')}</span>
           </Link>
 
           <div className="hidden lg:block flex-1 max-w-md ml-auto">


### PR DESCRIPTION
## Summary
Closes 5 high/medium-severity dogfood findings (`.ai-reports/dogfood-2026-05-04-post-algolia/report.md`). Same root cause across all of them: components rendering hardcoded English instead of `useTranslations()` despite the i18n keys existing or being trivially addable.

## What got fixed

| Issue | Before (/fr) | After (/fr) |
|---|---|---|
| ISSUE-002 (/fr/nouvelles + every listing) | `News` header, `All Items / Document for Comment / ...` pills, `SORT BY / ITEMS PER PAGE / START DATE / END DATE` | `Nouvelles`, `Tous les éléments / Document à commenter / Activité internationale / ...`, `TRIER PAR / ÉLÉMENTS PAR PAGE / DATE DE DÉBUT / DATE DE FIN` |
| ISSUE-003 (/fr/cnc board landing) | H1 `AcSB — ...`, breadcrumb `Accueil > AcSB`, `QUICK ACTIONS` sidebar | H1 `CNC — Conseil des normes comptables`, breadcrumb `Accueil > CNC`, `ACTIONS RAPIDES` |
| ISSUE-004 (/fr/projets-actifs cards) | `PUBLIC COMMENT` badge, `Stage 2: Document de travail` | `COMMENTAIRES DU PUBLIC`, `Étape 2 : Document de travail` |
| ISSUE-005 (/fr/recherche result cards) | `NEWS` badge, `Read More →`, `April 16, 2026` | `NOUVELLES`, `Lire la suite →`, `16 avril 2026` |
| ISSUE-006 (site logo) | `RAS Canada` everywhere | `NIFC Canada` on /fr |

## Translation keys added (en.json + fr.json — 241/241 parity)

- `projects.stageLabel`
- `projects.badges.{exposureDraft, publicComment, survey, research, reExposureDraft}`
- `listings.{sortBy, itemsPerPage, type, startDate, endDate, allItems, loading, noItems, noNews, noResources, sortNewest, sortOldest}`
- `listings.newsCategories.{documentForComment, internationalActivity, meetingSummary, news, resource}`
- `boards.abbreviations.{acsb, psab, aasb, cssb, rasoc}`
- `search.{readMore, viewDocument, viewMore, watchRecording, readSummary, viewDetails, downloadGuide}`
- `search.contentTypes.{standard, news, webinar, meeting, guidance, consultation, decision, deadline, resource}`

## Validation
- [x] `npx tsc --noEmit` clean
- [x] `vitest run` — 350/350 pass
- [x] Live screenshots before/after on all 5 affected pages — see report

## Architectural notes
- **Board abbreviation lookup** (`boards.abbreviations.<lowercase EN abbr>`): the Boards collection's `abbreviation` field isn't `localized: true`, so it always returns the EN value. The lookup uses the lowercase EN abbreviation as the stable key (closed set of 5 boards) — enumerated in `KNOWN_BOARDS` rather than runtime-discovered. Migration to `localized: true` on the field is a separate follow-up that can drop this lookup.
- **News category api-value vs label split** (`NEWS_CATEGORY_DEFS`): the API filter value stays English (`Document for Comment`) so server-side filtering doesn't break — only the displayed pill label is localized.
- **Project badge labels** same split: `badge_type` API enum stays EN, label resolved through `BADGE_TYPE_TO_KEY`.
- **Locale-aware date format** added to `SearchPageClient.formatDate` — takes locale as a param and dispatches to `fr-CA` / `en-CA` Intl.

## Follow-ups (not in this PR)
- BoardSidebar / FilterSidebar still render EN board abbreviations — same KNOWN_BOARDS lookup pattern would fix
- Resource categories (Article, Guidance, In Brief, Other, Webinar) + Type values (Audio, External Link, PDF, Video, Webpage) need dictionary additions
- ListingItem date format / category badge on news cards still EN — content-data localization, separate concern
- Next-intl `t.has()` check — current fallback is closed-set Set guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)