### PR TITLE
fix(i18n): localize board abbreviations in 3 more sidebars (dogfood follow-up)

### DIFF
--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -235,6 +235,11 @@ function AccordionSection({
   )
 }
 
+/** Closed-set lookup for board abbreviations — Boards.abbreviation is
+    not localized at the data layer, so the EN value (CSSB/AcSB/...) gets
+    swapped to the locale-equivalent (CCNID/CNC/...) at render time. */
+const KNOWN_BOARDS = new Set(['acsb', 'psab', 'aasb', 'cssb', 'rasoc'])
+
 export function FilterSidebar({
   activeFilters = {},
   onFilterChange,
@@ -244,6 +249,26 @@ export function FilterSidebar({
   const tSearch = useTranslations('search')
   const tFilters = useTranslations('filters')
   const tCommon = useTranslations('common')
+  const tBoards = useTranslations('boards')
+
+  /** Translate facet option labels for known boards. Filter VALUES stay
+      EN — they're sent to Algolia's filter expression and need to match
+      the indexed `board` field (which is always EN per the sync transform).
+      Falls back to the raw label if the dictionary entry is missing
+      (next-intl returns the key path in that case — never leak it). */
+  const localizeSection = (section: FilterSection): FilterSection => {
+    if (section.id !== 'board') return section
+    return {
+      ...section,
+      options: section.options.map((opt) => {
+        const key = opt.value.toLowerCase()
+        if (!KNOWN_BOARDS.has(key)) return opt
+        const lookupKey = `abbreviations.${key}`
+        const value = tBoards(lookupKey)
+        return value && value !== lookupKey ? { ...opt, label: value } : opt
+      }),
+    }
+  }
 
   // Track which accordion sections are open (all open by default)
   const [openSections, setOpenSections] = useState<Set<string>>(
@@ -296,7 +321,7 @@ export function FilterSidebar({
       {DEFAULT_SECTIONS.map((section) => (
         <AccordionSection
           key={section.id}
-          section={section}
+          section={localizeSection(section)}
           activeValues={activeFilters[section.id] || []}
           isOpen={openSections.has(section.id)}
           onToggle={() => toggleSection(section.id)}

--- a/src/components/SearchResultCard.tsx
+++ b/src/components/SearchResultCard.tsx
@@ -88,8 +88,23 @@ export function SearchResultCard({
   className = '',
 }: SearchResultCardProps) {
   const t = useTranslations('search')
+  const tBoards = useTranslations('boards')
   const ctaText = t(ctaKeyMap[contentType] || 'readMore')
   const displayBadge = badgeLabel || t(`contentTypes.${contentType}`)
+
+  // Same KNOWN_BOARDS lookup pattern used in BoardLanding/BoardNav/FilterSidebar:
+  // the search index `board` field stores the EN abbreviation; swap to the
+  // locale-equivalent for display.
+  const KNOWN_BOARDS = new Set(['acsb', 'psab', 'aasb', 'cssb', 'rasoc'])
+  let boardLabel = board || ''
+  if (board) {
+    const k = board.toLowerCase()
+    if (KNOWN_BOARDS.has(k)) {
+      const lookup = `abbreviations.${k}`
+      const value = tBoards(lookup)
+      if (value && value !== lookup) boardLabel = value
+    }
+  }
 
   return (
     <article
@@ -99,8 +114,8 @@ export function SearchResultCard({
       {/* Top row: badge + board + date */}
       <div className="mb-2 flex flex-wrap items-center gap-2">
         <Badge variant={contentType}>{displayBadge}</Badge>
-        {board && (
-          <span className="text-xs font-medium text-text-muted">{board}</span>
+        {boardLabel && (
+          <span className="text-xs font-medium text-text-muted">{boardLabel}</span>
         )}
         {date && (
           <>

--- a/src/components/board/BoardLanding.tsx
+++ b/src/components/board/BoardLanding.tsx
@@ -96,11 +96,17 @@ export async function BoardLanding({ board, locale }: BoardLandingProps) {
   // localized equivalent ("CNC") via `boards.abbreviations.<key>` keyed on
   // the lowercase EN abbreviation. The set of boards is closed (5) so the
   // safe-key list is enumerated in code rather than discovered at runtime.
+  // Also guard against next-intl returning the unresolved key path when
+  // the dictionary entry is missing — fall back to the raw abbreviation
+  // so the page never renders `abbreviations.acsb` literally.
   const KNOWN_BOARDS = new Set(['acsb', 'psab', 'aasb', 'cssb', 'rasoc'])
   const abbrKey = (board.abbreviation || '').toLowerCase()
-  const localizedAbbreviation = KNOWN_BOARDS.has(abbrKey)
-    ? tBoards(`abbreviations.${abbrKey}`)
-    : board.abbreviation || board.name
+  const lookupKey = `abbreviations.${abbrKey}`
+  const lookupValue = KNOWN_BOARDS.has(abbrKey) ? tBoards(lookupKey) : ''
+  const localizedAbbreviation =
+    lookupValue && lookupValue !== lookupKey
+      ? lookupValue
+      : board.abbreviation || board.name
 
   // Breadcrumb prepends its own localized Home crumb — we only pass the
   // board entry (the Breadcrumb component strips a literal `'Home'` first

--- a/src/components/board/BoardNav.tsx
+++ b/src/components/board/BoardNav.tsx
@@ -29,6 +29,25 @@ export type BoardNavItem = {
   abbreviation: string
 }
 
+/** Same closed-set lookup used by BoardLanding — the Boards collection's
+    `abbreviation` field isn't `localized: true`, so it always returns the
+    EN value. Maps EN abbreviation → i18n key under `boards.abbreviations.*`
+    so the displayed label is locale-aware. */
+const KNOWN_BOARDS = new Set(['acsb', 'psab', 'aasb', 'cssb', 'rasoc'])
+
+function localizedBoardLabel(
+  board: { abbreviation: string; name: string },
+  t: (key: string) => string,
+): string {
+  const key = (board.abbreviation || '').toLowerCase()
+  if (!KNOWN_BOARDS.has(key)) return board.abbreviation || board.name
+  // next-intl returns the key path when an entry is missing; never let
+  // `abbreviations.acsb` literal leak through to the UI.
+  const lookupKey = `abbreviations.${key}`
+  const value = t(lookupKey)
+  return value && value !== lookupKey ? value : board.abbreviation || board.name
+}
+
 type BoardNavProps = {
   /** Board items from CMS */
   boards: BoardNavItem[]
@@ -89,7 +108,7 @@ export function BoardNav({
                 aria-current={activeBoard === board.slug ? 'true' : undefined}
                 data-testid={`board-nav-${board.slug}`}
               >
-                {board.abbreviation || board.name}
+                {localizedBoardLabel(board, tBoards)}
               </button>
             </li>
           ))}


### PR DESCRIPTION
## Summary
Closes the chrome-bleed follow-up from PR #234. Board abbreviations were still showing in EN on /fr inside three more callsites — same root cause as the BoardLanding fix in #234.

| Location | Before (/fr) | After (/fr) |
|---|---|---|
| `/fr/projets-actifs` sidebar (`BoardNav`) | CSSB / AcSB / PSAB / AASB | CCNID / CNC / CCSP / CNAC |
| `/fr/recherche` filter sidebar (`FilterSidebar` "Par conseil") | CSSB / AcSB / PSAB / AASB | CCNID / CNC / CCSP / CNAC |
| `/fr/recherche` result-card metadata row (`SearchResultCard`) | "NOUVELLES AASB 16 avril 2026" | "NOUVELLES CNAC 16 avril 2026" |

## What changed

- **`BoardNav.tsx`** — extracted `localizedBoardLabel(board, t)` helper, used by both desktop list + mobile dropdown
- **`FilterSidebar.tsx`** — `localizeSection()` resolves board facet option labels in-flight before passing to `AccordionSection`. **Filter VALUES stay EN** because they're sent to Algolia's filter expression and need to match the indexed `board` field
- **`SearchResultCard.tsx`** — `boardLabel` resolved from the raw EN `board` prop at render time
- **`BoardLanding.tsx`** — retroactively hardened the PR #234 lookup with a missing-key guard

## Missing-key guard
Everywhere I check if `t(key)` returned the unresolved path (next-intl's missing-key fallback when entries are absent or test stubs are simplistic) and fall back to the raw EN abbreviation. Prevents `abbreviations.acsb` from ever leaking to the UI.

## Validation
- [x] `npx tsc --noEmit` clean
- [x] `vitest run` — 350/350 pass (BoardLanding tests work correctly with the new fallback under stubbed `useTranslations`)

## Architectural note
The closed-set `KNOWN_BOARDS` lookup is a stop-gap. The right long-term fix is making `Boards.abbreviation` a `localized: true` field at the data layer — removes the need for the i18n map entirely. Separate follow-up (requires a Payload migration + re-seeding the FR values). Once that lands, the lookup blocks become deletable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)