### PR TITLE
fix(search): per-locale Algolia index — /fr/recherche now returns FR hits

### DIFF
--- a/src/app/(frontend)/[locale]/(frontend)/search/SearchPageClient.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/search/SearchPageClient.tsx
@@ -154,13 +154,16 @@ function ResultsStats() {
 /** Sort dropdown — hidden when there are no hits, since sort is a no-op against an empty result set */
 function SortControl() {
   const t = useTranslations('search')
+  const locale = useLocale()
   const { nbHits } = useStats()
   // Sort option labels rebuild from translations on every render so they
-  // re-evaluate on locale change; values stay stable (Meilisearch index keys).
+  // re-evaluate on locale change. Sort `value`s reference the active
+  // per-locale Algolia index — Algolia replicas are keyed by index name.
+  const indexName = `news_${locale}`
   const { currentRefinement, options, refine } = useSortBy({
     items: [
-      { label: t('sortRelevance'), value: 'news_en' },
-      { label: t('sortDate'), value: 'news_en:date:desc' },
+      { label: t('sortRelevance'), value: indexName },
+      { label: t('sortDate'), value: `${indexName}:date:desc` },
     ],
   })
 
@@ -412,13 +415,19 @@ export function SearchPageClient({ popularTags }: SearchPageClientProps) {
   const searchParams = useSearchParams()
   const initialQuery = searchParams.get('q') || ''
 
+  // Per-locale Algolia index — the sync transform pushes EN content to
+  // `news_en` and FR content to `news_fr`. Hardcoding `news_en` (the
+  // pre-Slice 3 placeholder) caused /fr/recherche to return 0 hits for
+  // FR queries because they hit the wrong index.
+  const indexName = `news_${locale}`
+
   return (
     <InstantSearch
-      indexName="news_en"
+      indexName={indexName}
       /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
       searchClient={searchClient as any}
       initialUiState={{
-        news_en: { query: initialQuery },
+        [indexName]: { query: initialQuery },
       }}
     >
       <SearchContent popularTags={popularTags} />

--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -235,6 +235,11 @@ function AccordionSection({
   )
 }
 
+/** Closed-set lookup for board abbreviations — Boards.abbreviation is
+    not localized at the data layer, so the EN value (CSSB/AcSB/...) gets
+    swapped to the locale-equivalent (CCNID/CNC/...) at render time. */
+const KNOWN_BOARDS = new Set(['acsb', 'psab', 'aasb', 'cssb', 'rasoc'])
+
 export function FilterSidebar({
   activeFilters = {},
   onFilterChange,
@@ -244,6 +249,26 @@ export function FilterSidebar({
   const tSearch = useTranslations('search')
   const tFilters = useTranslations('filters')
   const tCommon = useTranslations('common')
+  const tBoards = useTranslations('boards')
+
+  /** Translate facet option labels for known boards. Filter VALUES stay
+      EN — they're sent to Algolia's filter expression and need to match
+      the indexed `board` field (which is always EN per the sync transform).
+      Falls back to the raw label if the dictionary entry is missing
+      (next-intl returns the key path in that case — never leak it). */
+  const localizeSection = (section: FilterSection): FilterSection => {
+    if (section.id !== 'board') return section
+    return {
+      ...section,
+      options: section.options.map((opt) => {
+        const key = opt.value.toLowerCase()
+        if (!KNOWN_BOARDS.has(key)) return opt
+        const lookupKey = `abbreviations.${key}`
+        const value = tBoards(lookupKey)
+        return value && value !== lookupKey ? { ...opt, label: value } : opt
+      }),
+    }
+  }
 
   // Track which accordion sections are open (all open by default)
   const [openSections, setOpenSections] = useState<Set<string>>(
@@ -296,7 +321,7 @@ export function FilterSidebar({
       {DEFAULT_SECTIONS.map((section) => (
         <AccordionSection
           key={section.id}
-          section={section}
+          section={localizeSection(section)}
           activeValues={activeFilters[section.id] || []}
           isOpen={openSections.has(section.id)}
           onToggle={() => toggleSection(section.id)}

--- a/src/components/SearchResultCard.tsx
+++ b/src/components/SearchResultCard.tsx
@@ -88,8 +88,23 @@ export function SearchResultCard({
   className = '',
 }: SearchResultCardProps) {
   const t = useTranslations('search')
+  const tBoards = useTranslations('boards')
   const ctaText = t(ctaKeyMap[contentType] || 'readMore')
   const displayBadge = badgeLabel || t(`contentTypes.${contentType}`)
+
+  // Same KNOWN_BOARDS lookup pattern used in BoardLanding/BoardNav/FilterSidebar:
+  // the search index `board` field stores the EN abbreviation; swap to the
+  // locale-equivalent for display.
+  const KNOWN_BOARDS = new Set(['acsb', 'psab', 'aasb', 'cssb', 'rasoc'])
+  let boardLabel = board || ''
+  if (board) {
+    const k = board.toLowerCase()
+    if (KNOWN_BOARDS.has(k)) {
+      const lookup = `abbreviations.${k}`
+      const value = tBoards(lookup)
+      if (value && value !== lookup) boardLabel = value
+    }
+  }
 
   return (
     <article
@@ -99,8 +114,8 @@ export function SearchResultCard({
       {/* Top row: badge + board + date */}
       <div className="mb-2 flex flex-wrap items-center gap-2">
         <Badge variant={contentType}>{displayBadge}</Badge>
-        {board && (
-          <span className="text-xs font-medium text-text-muted">{board}</span>
+        {boardLabel && (
+          <span className="text-xs font-medium text-text-muted">{boardLabel}</span>
         )}
         {date && (
           <>

--- a/src/components/board/BoardLanding.tsx
+++ b/src/components/board/BoardLanding.tsx
@@ -96,11 +96,17 @@ export async function BoardLanding({ board, locale }: BoardLandingProps) {
   // localized equivalent ("CNC") via `boards.abbreviations.<key>` keyed on
   // the lowercase EN abbreviation. The set of boards is closed (5) so the
   // safe-key list is enumerated in code rather than discovered at runtime.
+  // Also guard against next-intl returning the unresolved key path when
+  // the dictionary entry is missing — fall back to the raw abbreviation
+  // so the page never renders `abbreviations.acsb` literally.
   const KNOWN_BOARDS = new Set(['acsb', 'psab', 'aasb', 'cssb', 'rasoc'])
   const abbrKey = (board.abbreviation || '').toLowerCase()
-  const localizedAbbreviation = KNOWN_BOARDS.has(abbrKey)
-    ? tBoards(`abbreviations.${abbrKey}`)
-    : board.abbreviation || board.name
+  const lookupKey = `abbreviations.${abbrKey}`
+  const lookupValue = KNOWN_BOARDS.has(abbrKey) ? tBoards(lookupKey) : ''
+  const localizedAbbreviation =
+    lookupValue && lookupValue !== lookupKey
+      ? lookupValue
+      : board.abbreviation || board.name
 
   // Breadcrumb prepends its own localized Home crumb — we only pass the
   // board entry (the Breadcrumb component strips a literal `'Home'` first

--- a/src/components/board/BoardNav.tsx
+++ b/src/components/board/BoardNav.tsx
@@ -29,6 +29,25 @@ export type BoardNavItem = {
   abbreviation: string
 }
 
+/** Same closed-set lookup used by BoardLanding — the Boards collection's
+    `abbreviation` field isn't `localized: true`, so it always returns the
+    EN value. Maps EN abbreviation → i18n key under `boards.abbreviations.*`
+    so the displayed label is locale-aware. */
+const KNOWN_BOARDS = new Set(['acsb', 'psab', 'aasb', 'cssb', 'rasoc'])
+
+function localizedBoardLabel(
+  board: { abbreviation: string; name: string },
+  t: (key: string) => string,
+): string {
+  const key = (board.abbreviation || '').toLowerCase()
+  if (!KNOWN_BOARDS.has(key)) return board.abbreviation || board.name
+  // next-intl returns the key path when an entry is missing; never let
+  // `abbreviations.acsb` literal leak through to the UI.
+  const lookupKey = `abbreviations.${key}`
+  const value = t(lookupKey)
+  return value && value !== lookupKey ? value : board.abbreviation || board.name
+}
+
 type BoardNavProps = {
   /** Board items from CMS */
   boards: BoardNavItem[]
@@ -89,7 +108,7 @@ export function BoardNav({
                 aria-current={activeBoard === board.slug ? 'true' : undefined}
                 data-testid={`board-nav-${board.slug}`}
               >
-                {board.abbreviation || board.name}
+                {localizedBoardLabel(board, tBoards)}
               </button>
             </li>
           ))}


### PR DESCRIPTION
## Summary
`/fr/recherche?q=normes` returned 0 hits because `SearchPageClient.tsx` hardcoded `indexName=\"news_en\"`. FR content actually lives in `news_fr` per the algolia/sync.ts transform — the hardcode was the entire problem.

Stacks on PR #235 (board-abbreviation cleanup) so the test suite passes.

## Changes
- `<InstantSearch>` `indexName` + `initialUiState` key now derive from `news_${locale}` instead of literal `news_en`
- `SortControl`'s `useSortBy` items reference the per-locale index for both \"Relevance\" + \"Date desc\" sort (Algolia replicas are keyed by index name)

## Live verification (after dev restart)

| URL | Hits | Notes |
|---|---|---|
| `/fr/recherche?q=normes` | **9 résultats trouvés** (was 0) | Real FR content: \"Nomination du nouveau président du CNAC\", \"Le CCNID tient sa première réunion publique du conseil\" |
| `/en/search?q=standards` | 11 results (unchanged) | EN content + EN chrome unchanged |

Both pages render in their respective locale chrome (NOUVELLES vs NEWS, Lire la suite vs Read More, fr-CA vs en-CA dates) — confirms PR #234 + #235 are intact.

## Validation
- [x] `npx tsc --noEmit` clean
- [x] `vitest run` — 350/350 pass
- [x] /fr screenshot: shows 9 FR-language hits about CNAC + CCNID
- [x] /en screenshot: shows 11 EN-language hits unchanged

Closes the highest-impact \"known follow-up\" from the PR #231/#232 review and the dogfood report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)