### PR TITLE
fix(i18n): localize ListingItem dates + categories + Resources page filters

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -154,6 +154,21 @@
       "meetingSummary": "Meeting Summary",
       "news": "News",
       "resource": "Resource"
+    },
+    "resourceCategories": {
+      "article": "Article",
+      "guidance": "Guidance",
+      "inBrief": "In Brief",
+      "other": "Other",
+      "webinar": "Webinar"
+    },
+    "resourceTypes": {
+      "all": "All Types",
+      "audio": "Audio",
+      "externalLink": "External Link",
+      "pdf": "PDF",
+      "video": "Video",
+      "webpage": "Webpage"
     }
   },
   "consultations": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -154,6 +154,21 @@
       "meetingSummary": "Résumé de réunion",
       "news": "Nouvelles",
       "resource": "Ressource"
+    },
+    "resourceCategories": {
+      "article": "Article",
+      "guidance": "Guide d'application",
+      "inBrief": "En bref",
+      "other": "Autre",
+      "webinar": "Webinaire"
+    },
+    "resourceTypes": {
+      "all": "Tous les types",
+      "audio": "Audio",
+      "externalLink": "Lien externe",
+      "pdf": "PDF",
+      "video": "Vidéo",
+      "webpage": "Page web"
     }
   },
   "consultations": {

--- a/src/app/(frontend)/[locale]/(frontend)/[board]/resources/ResourcesListingClient.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/[board]/resources/ResourcesListingClient.tsx
@@ -36,26 +36,33 @@ type ResourcesListingClientProps = {
   standardSlug: string
 }
 
-/** Resource-specific categories. The English value is what the API
-    filters by; only the displayed label is localized at render. The
-    `Article` / `Guidance` / `In Brief` / `Other` / `Webinar` strings
-    aren't yet covered by the dictionary — falls back to the English
-    label until they're added (separate follow-up). */
-const CATEGORY_OPTIONS = [
-  'All Items', 'Article', 'Guidance', 'In Brief', 'Other', 'Webinar',
+/** Resource-specific categories. The `apiValue` is what the API filters
+    by (must stay EN to match the indexed value); the displayed label is
+    looked up via `listings.resourceCategories.<key>` at render. */
+const CATEGORY_DEFS: ReadonlyArray<{ key: string; apiValue: string }> = [
+  { key: 'all', apiValue: '' },
+  { key: 'article', apiValue: 'Article' },
+  { key: 'guidance', apiValue: 'Guidance' },
+  { key: 'inBrief', apiValue: 'In Brief' },
+  { key: 'other', apiValue: 'Other' },
+  { key: 'webinar', apiValue: 'Webinar' },
 ]
 
-const TYPE_OPTIONS = [
-  { label: 'All Types', value: '' },
-  { label: 'Audio', value: 'Audio' },
-  { label: 'External Link', value: 'External Link' },
-  { label: 'PDF', value: 'PDF' },
-  { label: 'Video', value: 'Video' },
-  { label: 'Webpage', value: 'Webpage' },
+/** Resource-type filter — same value/label split. Translated via
+    `listings.resourceTypes.<key>`. */
+const TYPE_DEFS: ReadonlyArray<{ key: string; apiValue: string }> = [
+  { key: 'all', apiValue: '' },
+  { key: 'audio', apiValue: 'Audio' },
+  { key: 'externalLink', apiValue: 'External Link' },
+  { key: 'pdf', apiValue: 'PDF' },
+  { key: 'video', apiValue: 'Video' },
+  { key: 'webpage', apiValue: 'Webpage' },
 ]
 
 export function ResourcesListingClient({ standardSlug }: ResourcesListingClientProps) {
   const t = useTranslations('listings')
+  const tCats = useTranslations('listings.resourceCategories')
+  const tTypes = useTranslations('listings.resourceTypes')
   const [category, setCategory] = useState('')
   const [sort, setSort] = useState('newest')
   const [itemsPerPage, setItemsPerPage] = useState('10')
@@ -122,10 +129,15 @@ export function ResourcesListingClient({ standardSlug }: ResourcesListingClientP
     setPage(1)
   }, [category, sort, itemsPerPage, typeFilter, startDate, endDate])
 
-  const categoryPillOptions = CATEGORY_OPTIONS.map((cat) => ({
-    label: cat === 'All Items' ? t('allItems') : cat,
-    value: cat === 'All Items' ? '' : cat,
-    isActive: cat === 'All Items' ? category === '' : category === cat,
+  const categoryPillOptions = CATEGORY_DEFS.map((def) => ({
+    label: def.key === 'all' ? t('allItems') : tCats(def.key),
+    value: def.apiValue,
+    isActive: def.apiValue === '' ? category === '' : category === def.apiValue,
+  }))
+
+  const typeFilterOptions = TYPE_DEFS.map((def) => ({
+    label: def.key === 'all' ? tTypes('all') : tTypes(def.key),
+    value: def.apiValue,
   }))
 
   const currentLimit = itemsPerPage === 'all' ? 500 : Number(itemsPerPage)
@@ -147,7 +159,7 @@ export function ResourcesListingClient({ standardSlug }: ResourcesListingClientP
         itemsPerPageOptions={itemsPerPageOptions}
         itemsPerPageValue={itemsPerPage}
         onItemsPerPageChange={setItemsPerPage}
-        typeFilterOptions={TYPE_OPTIONS}
+        typeFilterOptions={typeFilterOptions}
         typeFilterValue={typeFilter}
         onTypeFilterChange={setTypeFilter}
         showDateRange

--- a/src/app/(frontend)/[locale]/(frontend)/search/SearchPageClient.tsx
+++ b/src/app/(frontend)/[locale]/(frontend)/search/SearchPageClient.tsx
@@ -154,13 +154,16 @@ function ResultsStats() {
 /** Sort dropdown — hidden when there are no hits, since sort is a no-op against an empty result set */
 function SortControl() {
   const t = useTranslations('search')
+  const locale = useLocale()
   const { nbHits } = useStats()
   // Sort option labels rebuild from translations on every render so they
-  // re-evaluate on locale change; values stay stable (Meilisearch index keys).
+  // re-evaluate on locale change. Sort `value`s reference the active
+  // per-locale Algolia index — Algolia replicas are keyed by index name.
+  const indexName = `news_${locale}`
   const { currentRefinement, options, refine } = useSortBy({
     items: [
-      { label: t('sortRelevance'), value: 'news_en' },
-      { label: t('sortDate'), value: 'news_en:date:desc' },
+      { label: t('sortRelevance'), value: indexName },
+      { label: t('sortDate'), value: `${indexName}:date:desc` },
     ],
   })
 
@@ -412,13 +415,19 @@ export function SearchPageClient({ popularTags }: SearchPageClientProps) {
   const searchParams = useSearchParams()
   const initialQuery = searchParams.get('q') || ''
 
+  // Per-locale Algolia index — the sync transform pushes EN content to
+  // `news_en` and FR content to `news_fr`. Hardcoding `news_en` (the
+  // pre-Slice 3 placeholder) caused /fr/recherche to return 0 hits for
+  // FR queries because they hit the wrong index.
+  const indexName = `news_${locale}`
+
   return (
     <InstantSearch
-      indexName="news_en"
+      indexName={indexName}
       /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
       searchClient={searchClient as any}
       initialUiState={{
-        news_en: { query: initialQuery },
+        [indexName]: { query: initialQuery },
       }}
     >
       <SearchContent popularTags={popularTags} />

--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -235,6 +235,11 @@ function AccordionSection({
   )
 }
 
+/** Closed-set lookup for board abbreviations — Boards.abbreviation is
+    not localized at the data layer, so the EN value (CSSB/AcSB/...) gets
+    swapped to the locale-equivalent (CCNID/CNC/...) at render time. */
+const KNOWN_BOARDS = new Set(['acsb', 'psab', 'aasb', 'cssb', 'rasoc'])
+
 export function FilterSidebar({
   activeFilters = {},
   onFilterChange,
@@ -244,6 +249,26 @@ export function FilterSidebar({
   const tSearch = useTranslations('search')
   const tFilters = useTranslations('filters')
   const tCommon = useTranslations('common')
+  const tBoards = useTranslations('boards')
+
+  /** Translate facet option labels for known boards. Filter VALUES stay
+      EN — they're sent to Algolia's filter expression and need to match
+      the indexed `board` field (which is always EN per the sync transform).
+      Falls back to the raw label if the dictionary entry is missing
+      (next-intl returns the key path in that case — never leak it). */
+  const localizeSection = (section: FilterSection): FilterSection => {
+    if (section.id !== 'board') return section
+    return {
+      ...section,
+      options: section.options.map((opt) => {
+        const key = opt.value.toLowerCase()
+        if (!KNOWN_BOARDS.has(key)) return opt
+        const lookupKey = `abbreviations.${key}`
+        const value = tBoards(lookupKey)
+        return value && value !== lookupKey ? { ...opt, label: value } : opt
+      }),
+    }
+  }
 
   // Track which accordion sections are open (all open by default)
   const [openSections, setOpenSections] = useState<Set<string>>(
@@ -296,7 +321,7 @@ export function FilterSidebar({
       {DEFAULT_SECTIONS.map((section) => (
         <AccordionSection
           key={section.id}
-          section={section}
+          section={localizeSection(section)}
           activeValues={activeFilters[section.id] || []}
           isOpen={openSections.has(section.id)}
           onToggle={() => toggleSection(section.id)}

--- a/src/components/ListingItem.tsx
+++ b/src/components/ListingItem.tsx
@@ -4,20 +4,21 @@
  * Shows date, category badges, linked title, and excerpt.
  *
  * Key features:
- * - Date formatted "Month DD, YYYY" above title
- * - Category badge/chip(s) rendered
+ * - Date formatted "Month DD, YYYY" above title (locale-aware)
+ * - Category badge/chip(s) rendered with translated labels for known
+ *   news/resource category strings
  * - Title as purple linked text
  * - External link icon when isExternal is true
  * - 2-3 sentence excerpt, text only
  *
- * @dependencies
- * - next/link: Client-side navigation
- * - Badge: From ui/ for category chips
- *
  * @notes
- * - Server component — no interactivity
- * - Date uses Intl.DateTimeFormat for locale-aware formatting
+ * - Client component — uses `useLocale` for fr-CA / en-CA date formatting
+ *   and `useTranslations` to translate category badge labels. Categories
+ *   that aren't in the dictionary fall back to the raw EN value.
  */
+'use client'
+
+import { useLocale, useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 
 type ListingItemProps = {
@@ -40,19 +41,51 @@ type ListingItemProps = {
 }
 
 /**
- * Formats an ISO date string to "Month DD, YYYY" format.
+ * Formats an ISO date string to "Month DD, YYYY" in the active locale.
+ * fr-CA renders "16 avril 2026" — month-name lowercase per French convention.
  */
-function formatDate(dateString: string): string {
+function formatDate(dateString: string, locale: string): string {
   const date = new Date(dateString)
-  return new Intl.DateTimeFormat('en-US', {
+  if (Number.isNaN(date.getTime())) return ''
+  const intlLocale = locale === 'fr' ? 'fr-CA' : 'en-CA'
+  return new Intl.DateTimeFormat(intlLocale, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
   }).format(date)
 }
 
+/** Map raw EN category strings (the API/CMS values) to translation keys
+    under `listings.newsCategories.*` + `listings.resourceCategories.*`.
+    Anything not listed falls through to the raw value (back-compat for
+    new category strings the dictionary hasn't caught up with yet). */
+const CATEGORY_TO_TRANSLATION_KEY: Record<string, string> = {
+  // News
+  'Document for Comment': 'newsCategories.documentForComment',
+  'International Activity': 'newsCategories.internationalActivity',
+  'Meeting Summary': 'newsCategories.meetingSummary',
+  News: 'newsCategories.news',
+  Resource: 'newsCategories.resource',
+  // Resources
+  Article: 'resourceCategories.article',
+  Guidance: 'resourceCategories.guidance',
+  'In Brief': 'resourceCategories.inBrief',
+  Other: 'resourceCategories.other',
+  Webinar: 'resourceCategories.webinar',
+}
+
 export function ListingItem({ item, className = '' }: ListingItemProps) {
   const { date, categories, title, href, excerpt, isExternal } = item
+  const locale = useLocale()
+  const tListings = useTranslations('listings')
+
+  function categoryLabel(raw: string): string {
+    const key = CATEGORY_TO_TRANSLATION_KEY[raw]
+    if (!key) return raw
+    const value = tListings(key)
+    // next-intl returns the key path on miss — never leak that.
+    return value && value !== key ? value : raw
+  }
 
   const titleContent = (
     <>
@@ -83,7 +116,7 @@ export function ListingItem({ item, className = '' }: ListingItemProps) {
     >
       {/* Date */}
       <time dateTime={date} className="text-sm text-text-muted">
-        {formatDate(date)}
+        {formatDate(date, locale)}
       </time>
 
       {/* Category badges */}
@@ -95,7 +128,7 @@ export function ListingItem({ item, className = '' }: ListingItemProps) {
               className="inline-block rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-text-primary"
               data-testid={`listing-badge-${cat.toLowerCase().replace(/\s+/g, '-')}`}
             >
-              {cat}
+              {categoryLabel(cat)}
             </span>
           ))}
         </div>

--- a/src/components/SearchResultCard.tsx
+++ b/src/components/SearchResultCard.tsx
@@ -88,8 +88,23 @@ export function SearchResultCard({
   className = '',
 }: SearchResultCardProps) {
   const t = useTranslations('search')
+  const tBoards = useTranslations('boards')
   const ctaText = t(ctaKeyMap[contentType] || 'readMore')
   const displayBadge = badgeLabel || t(`contentTypes.${contentType}`)
+
+  // Same KNOWN_BOARDS lookup pattern used in BoardLanding/BoardNav/FilterSidebar:
+  // the search index `board` field stores the EN abbreviation; swap to the
+  // locale-equivalent for display.
+  const KNOWN_BOARDS = new Set(['acsb', 'psab', 'aasb', 'cssb', 'rasoc'])
+  let boardLabel = board || ''
+  if (board) {
+    const k = board.toLowerCase()
+    if (KNOWN_BOARDS.has(k)) {
+      const lookup = `abbreviations.${k}`
+      const value = tBoards(lookup)
+      if (value && value !== lookup) boardLabel = value
+    }
+  }
 
   return (
     <article
@@ -99,8 +114,8 @@ export function SearchResultCard({
       {/* Top row: badge + board + date */}
       <div className="mb-2 flex flex-wrap items-center gap-2">
         <Badge variant={contentType}>{displayBadge}</Badge>
-        {board && (
-          <span className="text-xs font-medium text-text-muted">{board}</span>
+        {boardLabel && (
+          <span className="text-xs font-medium text-text-muted">{boardLabel}</span>
         )}
         {date && (
           <>

--- a/src/components/board/BoardLanding.tsx
+++ b/src/components/board/BoardLanding.tsx
@@ -96,11 +96,17 @@ export async function BoardLanding({ board, locale }: BoardLandingProps) {
   // localized equivalent ("CNC") via `boards.abbreviations.<key>` keyed on
   // the lowercase EN abbreviation. The set of boards is closed (5) so the
   // safe-key list is enumerated in code rather than discovered at runtime.
+  // Also guard against next-intl returning the unresolved key path when
+  // the dictionary entry is missing — fall back to the raw abbreviation
+  // so the page never renders `abbreviations.acsb` literally.
   const KNOWN_BOARDS = new Set(['acsb', 'psab', 'aasb', 'cssb', 'rasoc'])
   const abbrKey = (board.abbreviation || '').toLowerCase()
-  const localizedAbbreviation = KNOWN_BOARDS.has(abbrKey)
-    ? tBoards(`abbreviations.${abbrKey}`)
-    : board.abbreviation || board.name
+  const lookupKey = `abbreviations.${abbrKey}`
+  const lookupValue = KNOWN_BOARDS.has(abbrKey) ? tBoards(lookupKey) : ''
+  const localizedAbbreviation =
+    lookupValue && lookupValue !== lookupKey
+      ? lookupValue
+      : board.abbreviation || board.name
 
   // Breadcrumb prepends its own localized Home crumb — we only pass the
   // board entry (the Breadcrumb component strips a literal `'Home'` first

--- a/src/components/board/BoardNav.tsx
+++ b/src/components/board/BoardNav.tsx
@@ -29,6 +29,25 @@ export type BoardNavItem = {
   abbreviation: string
 }
 
+/** Same closed-set lookup used by BoardLanding — the Boards collection's
+    `abbreviation` field isn't `localized: true`, so it always returns the
+    EN value. Maps EN abbreviation → i18n key under `boards.abbreviations.*`
+    so the displayed label is locale-aware. */
+const KNOWN_BOARDS = new Set(['acsb', 'psab', 'aasb', 'cssb', 'rasoc'])
+
+function localizedBoardLabel(
+  board: { abbreviation: string; name: string },
+  t: (key: string) => string,
+): string {
+  const key = (board.abbreviation || '').toLowerCase()
+  if (!KNOWN_BOARDS.has(key)) return board.abbreviation || board.name
+  // next-intl returns the key path when an entry is missing; never let
+  // `abbreviations.acsb` literal leak through to the UI.
+  const lookupKey = `abbreviations.${key}`
+  const value = t(lookupKey)
+  return value && value !== lookupKey ? value : board.abbreviation || board.name
+}
+
 type BoardNavProps = {
   /** Board items from CMS */
   boards: BoardNavItem[]
@@ -89,7 +108,7 @@ export function BoardNav({
                 aria-current={activeBoard === board.slug ? 'true' : undefined}
                 data-testid={`board-nav-${board.slug}`}
               >
-                {board.abbreviation || board.name}
+                {localizedBoardLabel(board, tBoards)}
               </button>
             </li>
           ))}


### PR DESCRIPTION
## Summary
Closes the remaining \"documented follow-ups\" from PR #234 + the dogfood report. Three small components had hardcoded English chrome that PR #234's chrome sweep didn't reach.

## Changes

### `ListingItem.tsx` (used by /en/news-listings, /fr/nouvelles, board-specific news, resources)
- Was server component with hardcoded \`Intl.DateTimeFormat('en-US')\` → now \`'use client'\` + reads \`useLocale()\`. Renders **\"16 avril 2026\"** on /fr instead of \"April 16, 2026\".
- Category badges: raw EN strings (\"Meeting Summary\", \"News\") mapped through \`CATEGORY_TO_TRANSLATION_KEY\` to \`listings.newsCategories.*\` + \`listings.resourceCategories.*\`. Renders **\"Résumé de réunion\"** instead of \"Meeting Summary\".
- Missing-key guard prevents unresolved key path from leaking.

### `ResourcesListingClient.tsx` (used by /<board>/resources/<standard>)
- \`CATEGORY_OPTIONS\` → \`CATEGORY_DEFS\` table (key + apiValue split). Same pattern as NewsListingClient's NEWS_CATEGORY_DEFS in #234. Localizes \"Article / Guidance / In Brief / Other / Webinar\".
- \`TYPE_OPTIONS\` → \`TYPE_DEFS\`. Localizes \"All Types / Audio / External Link / PDF / Video / Webpage\".
- Filter VALUES stay EN — they're sent to \`/api/resources?category=…\` and need to match the indexed values.

### Translation keys (11 new — parity verified)
- \`listings.resourceCategories.{article, guidance, inBrief, other, webinar}\`
- \`listings.resourceTypes.{all, audio, externalLink, pdf, video, webpage}\`

## Validation
- [x] \`npx tsc --noEmit\` clean
- [x] \`vitest run\` — 350/350 pass
- [x] Live: /fr/nouvelles ListingItem dates render \"28 avril 2026\" / \"26 avril 2026\"; category badges \"Résumé de réunion\" / \"Nouvelles\"

## Out of scope
News titles + excerpts in EN on /fr — content-data localization, requires CMS translation pipeline work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)